### PR TITLE
Add routeup exec and improve setup credential handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /dist/
 /routeup
 /routeup.exe
-/.routeup-dev/
 /.routeup-devel/
 
 # Test and coverage artifacts

--- a/PLAN.md
+++ b/PLAN.md
@@ -77,6 +77,7 @@ The normal commands should be small:
 ```bash
 routeup                                # script-runner / Portless mode
 routeup serve                          # serve a local route (default local-only)
+routeup exec -- <command>              # project environment without route ownership
 routeup serve --port 8080
 routeup serve api --port 8080
 routeup serve api.myapp --port 9080
@@ -93,7 +94,14 @@ routeup update
 routeup uninstall
 ```
 
-The split: `serve` creates a route (local by default; `--expose` or `expose.enabled` adds public exposure in one go). Standalone `expose` reuses an active route's targets when available, otherwise it exposes targets from flags or config without creating a local registration. Bare `routeup` is the Phase 8 local script runner; Phase 8.5 added `expose.enabled` for config-driven exposure before child launch. Framework-specific command adapters are out of scope.
+The split: `serve` creates a route (local by default; `--expose` or
+`expose.enabled` adds public exposure in one go). `exec` runs one configured or
+explicit command with Routeup's project URL and CA environment but never owns a
+route or exposure. Standalone `expose` reuses an active route's targets when
+available, otherwise it exposes targets from flags or config without creating a
+local registration. Bare `routeup` is the Phase 8 local script runner; Phase 8.5
+added `expose.enabled` for config-driven exposure before child launch.
+Framework-specific command adapters are out of scope.
 
 Operator-only commands:
 
@@ -227,6 +235,11 @@ Non-JavaScript projects put the shell command in `routeup.json`:
 loader resolves the selected script to its command string; the runner executes
 that string through `sh -c` and does not run package-manager lifecycle hooks for
 the selected child script.
+
+`routeup exec` uses the same configured `script` or `command` when invoked
+without arguments. An explicit argv after `--` overrides it. Exec injects the
+project's local URL, an active public URL when available, and local CA trust,
+but does not start the agent, register a route, expose it, or wait for a target.
 
 For frontend + API behind one route, use path targets:
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,30 @@ changes. Vite and Astro need one line of config — see
 (e.g. running from a directory called `myapp` gives `https://myapp.localhost`
 automatically).
 
+### Run supporting commands
+
+Use `routeup exec` when `routeup serve` owns the route but other processes need
+the same project URLs and local CA trust:
+
+```bash
+# terminal 1: own the route and optional public exposure
+routeup serve
+
+# other terminals: environment only, no route registration
+routeup exec -- yarn start:dev
+routeup exec -- yarn start:consumer:sync
+routeup exec -- yarn start:consumer:webhook
+```
+
+`exec` injects the configured port/host when present, `ROUTEUP_LOCAL_URL`,
+`ROUTEUP_URL`, `NODE_EXTRA_CA_CERTS`, and the project-local binary path. If the
+route already has a public exposure, `ROUTEUP_URL` uses that public URL;
+otherwise it matches the local URL. It does not start the agent, register or
+expose a route, or wait for a listening port.
+
+With no arguments, `routeup exec` runs the configured `script` or `command`.
+An explicit command after `--` takes precedence.
+
 For editor validation and completion, reference the committed JSON Schema from
 `routeup.json`:
 
@@ -155,6 +179,7 @@ Or save them permanently:
 
 ```bash
 routeup setup --server https://edge.routeup.dev
+routeup setup --token none              # clear the saved token, keep the server
 routeup setup --server none             # clear the saved server and token
 ```
 
@@ -263,6 +288,7 @@ contains terminal formatting.
 
 ```bash
 routeup dashboard   # interactive routes, exposures, live logs, and inspect
+routeup exec -- …   # run one command with the Routeup project environment
 routeup routes      # list active local routes (PUBLIC annotation when exposed)
 routeup doctor      # check CA, OS trust, port 443, and agent health
 routeup config      # show the discovered file and resolved non-secret settings

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,7 @@ routeup
 routeup serve
 routeup serve --port 8080
 routeup serve --port 8080 --expose
+routeup exec -- <command>
 routeup expose <name>
 routeup agent status
 routeup dashboard
@@ -604,6 +605,15 @@ config. The runner executes that string through `sh -c` with the project
 `node_modules/.bin` prepended to `PATH`; it does not invoke package-manager
 lifecycle hooks for the selected child script.
 
+`routeup exec` is the process-only half of runner mode. With no arguments it
+uses the same resolved config command; argv after `--` overrides it without
+shell interpolation. Exec computes the local route URL, uses an already-active
+public exposure for `ROUTEUP_URL` when available, injects local CA trust, and
+runs one child process group. It does not start the agent, register or expose a
+route, allocate a port, or perform readiness checks. This lets one `routeup
+serve` process own a multi-target route while independently launched workers
+share its environment without making routeup their supervisor.
+
 Bare-name resolution:
 
 ```txt
@@ -779,7 +789,7 @@ token outside allowed route scope
 target port not reachable
 tunnel disconnected
 public route offline
-path not exposed
+path does not exist or is not exposed
 ```
 
 `routeup doctor` should eventually diagnose most of these.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -451,6 +451,12 @@ and owns the child and route lifecycle.
 > supported. In an interactive terminal, the child group is foreground and
 > receives Ctrl-C directly; it must respond to SIGINT. A SIGTERM sent directly
 > to routeup uses the managed shutdown and escalation path.
+>
+> `routeup exec` reuses configured command/script resolution and child process
+> lifecycle for environment-only commands. Explicit argv after `--` overrides
+> config. It injects configured project URLs and local CA trust without starting
+> the agent, claiming or exposing a route, allocating a port, or waiting for
+> readiness.
 
 Build:
 
@@ -462,6 +468,7 @@ route register while child runs
 route unregister on exit
 signal handling
 child process exit-code propagation
+environment-only exec command
 ```
 
 Example package config:

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mukul-mehta/routeup/internal/agentctl"
+	"github.com/mukul-mehta/routeup/internal/certs"
+	"github.com/mukul-mehta/routeup/internal/config"
+	"github.com/mukul-mehta/routeup/internal/process"
+	"github.com/mukul-mehta/routeup/internal/state"
+)
+
+func newExecCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exec [-- <command> [args...]]",
+		Short: "Run a command with the Routeup project environment",
+		Long: "Run one command with Routeup's local URL and CA environment without\n" +
+			"starting the agent, registering a route, or creating a public exposure.\n\n" +
+			"With no command, exec uses the configured package.json script or\n" +
+			"routeup.json command. Put an explicit command after --.",
+		Example: "  routeup serve\n" +
+			"  routeup exec -- yarn start:dev\n" +
+			"  routeup exec -- yarn start:consumer:sync",
+		Args: validateExecArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting cwd: %w", err)
+			}
+			return runExec(cmd, cwd, args)
+		},
+	}
+	return cmd
+}
+
+func validateExecArgs(cmd *cobra.Command, args []string) error {
+	dash := cmd.ArgsLenAtDash()
+	if dash < 0 {
+		if len(args) > 0 {
+			return errors.New("put the command after -- (for example, `routeup exec -- yarn start:dev`)")
+		}
+		return nil
+	}
+	if dash != 0 {
+		return errors.New("put all command arguments after --")
+	}
+	if len(args) == 0 {
+		return errors.New("a command is required after --")
+	}
+	return nil
+}
+
+func runExec(cmd *cobra.Command, cwd string, argv []string) error {
+	discovered, err := config.Discover(cwd)
+	if err != nil {
+		return fmt.Errorf("discover config: %w", err)
+	}
+	file := discovered.Config
+
+	runner := process.Runner{Dir: cwd}
+	if len(argv) > 0 {
+		runner.Argv = append([]string(nil), argv...)
+	} else {
+		runner.Command = strings.TrimSpace(file.Command)
+		if runner.Command == "" {
+			return errors.New("nothing to execute: set \"script\" in your package.json routeup block, set \"command\" in routeup.json, or pass a command after --")
+		}
+	}
+
+	routeName, err := runnerRoute(file, cwd)
+	if err != nil {
+		return err
+	}
+	if err := certs.EnsureLocalCA(); err != nil {
+		return err
+	}
+	caCertPath, err := state.CACertPath()
+	if err != nil {
+		return err
+	}
+
+	parent := cmd.Context()
+	if parent == nil {
+		parent = context.Background()
+	}
+	local := localURL(routeName.LocalHost(), state.TLSPortOrDefault())
+	public := activeExecPublicURL(parent, cmd.Root().Version, routeName.String())
+	port, err := execConfiguredPort(file)
+	if err != nil {
+		return fmt.Errorf("resolve exec environment: %w", err)
+	}
+	runner.Env = process.InjectEnv(os.Environ(), process.EnvInputs{
+		Port:       port,
+		PortEnvVar: file.PortEnvVar,
+		Host:       "127.0.0.1",
+		LocalURL:   local,
+		PublicURL:  public,
+		CACertPath: caCertPath,
+		WorkDir:    cwd,
+	})
+
+	ctx, stop := process.NotifyContext(parent)
+	defer stop()
+	code, err := runner.Run(ctx, process.Stdio{
+		In:  cmd.InOrStdin(),
+		Out: cmd.OutOrStdout(),
+		Err: cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return fmt.Errorf("exec command: %w", err)
+	}
+	if code != 0 {
+		return &ExitError{Code: code}
+	}
+	return nil
+}
+
+func execConfiguredPort(file config.Config) (int, error) {
+	hasTargets := file.Port != 0 || len(file.Targets) > 0 || strings.TrimSpace(os.Getenv("ROUTEUP_PORT")) != ""
+	if !hasTargets {
+		return 0, nil
+	}
+	_, port, err := config.ResolveTargets(config.Inputs{Env: os.Getenv, File: file})
+	return port, err
+}
+
+func activeExecPublicURL(parent context.Context, version, routeName string) string {
+	socketPath, err := state.AgentSocketPath()
+	if err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(parent, time.Second)
+	defer cancel()
+	status, err := agentctl.NewClient(socketPath, "", version).Status(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, exposure := range status.Exposures {
+		if exposure.Route == routeName && exposure.Host != "" {
+			return "https://" + exposure.Host
+		}
+	}
+	return ""
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mukul-mehta/routeup/internal/ipc"
+	"github.com/mukul-mehta/routeup/internal/state"
+)
+
+func TestExecExplicitCommandInjectsProjectEnvironment(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(state.StateDirEnv, "")
+	writeLocalCA(t)
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "routeup.json"), []byte(`{
+  "name": "myapp",
+  "targets": [{"path": "/", "port": 3000}]
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	var unexpected atomic.Int32
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != ipc.PathStatus {
+			unexpected.Add(1)
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ipc.Status{Exposures: []ipc.ExposureStatus{{
+			Route: "myapp", Host: "myapp.example.com", State: ipc.ExposureConnected,
+		}}})
+	}))
+	t.Setenv("ROUTEUP_AGENT_SOCKET", socketPath)
+
+	stdout, _, err := runRoot(t, "exec", "--", "env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := parseEnvOutput(stdout)
+	certPath, err := state.CACertPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"HOST":                "127.0.0.1",
+		"PORT":                "3000",
+		"ROUTEUP_LOCAL_URL":   "https://myapp.localhost",
+		"ROUTEUP_URL":         "https://myapp.example.com",
+		"NODE_EXTRA_CA_CERTS": certPath,
+	}
+	for key, value := range want {
+		if env[key] != value {
+			t.Errorf("%s = %q, want %q", key, env[key], value)
+		}
+	}
+	wantPathPrefix := filepath.Join(cwd, "node_modules", ".bin") + string(os.PathListSeparator)
+	if !strings.HasPrefix(env["PATH"], wantPathPrefix) {
+		t.Errorf("PATH = %q, want prefix %q", env["PATH"], wantPathPrefix)
+	}
+	if unexpected.Load() != 0 {
+		t.Errorf("exec made %d unexpected agent requests", unexpected.Load())
+	}
+}
+
+func TestExecUsesConfiguredCommandOrScript(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		content  string
+	}{
+		{
+			name:     "routeup command",
+			filename: "routeup.json",
+			content:  `{"name":"myapp","command":"env"}`,
+		},
+		{
+			name:     "package script",
+			filename: "package.json",
+			content:  `{"scripts":{"show-env":"env"},"routeup":{"name":"myapp","script":"show-env"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv(state.StateDirEnv, "")
+			writeLocalCA(t)
+			cwd := t.TempDir()
+			if err := os.WriteFile(filepath.Join(cwd, tt.filename), []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(cwd)
+			t.Setenv("ROUTEUP_AGENT_SOCKET", filepath.Join(t.TempDir(), "missing.sock"))
+
+			stdout, _, err := runRoot(t, "exec")
+			if err != nil {
+				t.Fatal(err)
+			}
+			env := parseEnvOutput(stdout)
+			if env["ROUTEUP_LOCAL_URL"] != "https://myapp.localhost" {
+				t.Fatalf("ROUTEUP_LOCAL_URL = %q", env["ROUTEUP_LOCAL_URL"])
+			}
+			if env["ROUTEUP_URL"] != env["ROUTEUP_LOCAL_URL"] {
+				t.Fatalf("ROUTEUP_URL = %q, want local fallback", env["ROUTEUP_URL"])
+			}
+		})
+	}
+}
+
+func TestExecExplicitCommandOverridesConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(state.StateDirEnv, "")
+	writeLocalCA(t)
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "routeup.json"), []byte(`{"name":"myapp","command":"exit 17"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("ROUTEUP_AGENT_SOCKET", filepath.Join(t.TempDir(), "missing.sock"))
+
+	if _, _, err := runRoot(t, "exec", "--", "true"); err != nil {
+		t.Fatalf("explicit command did not override config: %v", err)
+	}
+}
+
+func TestExecArgumentValidation(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "explicit command needs separator", args: []string{"exec", "env"}, want: "after --"},
+		{name: "separator needs command", args: []string{"exec", "--"}, want: "command is required"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := runRoot(t, tt.args...)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecRequiresConfiguredOrExplicitCommand(t *testing.T) {
+	t.Chdir(t.TempDir())
+	_, _, err := runRoot(t, "exec")
+	if err == nil || !strings.Contains(err.Error(), "nothing to execute") {
+		t.Fatalf("error = %v, want missing command", err)
+	}
+}
+
+func TestExecPropagatesExitCode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(state.StateDirEnv, "")
+	writeLocalCA(t)
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "routeup.json"), []byte(`{"name":"myapp"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("ROUTEUP_AGENT_SOCKET", filepath.Join(t.TempDir(), "missing.sock"))
+
+	_, _, err := runRoot(t, "exec", "--", "sh", "-c", "exit 7")
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("error = %v, want exit code 7", err)
+	}
+}
+
+func parseEnvOutput(output string) map[string]string {
+	env := make(map[string]string)
+	for line := range strings.SplitSeq(output, "\n") {
+		if key, value, ok := strings.Cut(line, "="); ok {
+			env[key] = value
+		}
+	}
+	return env
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -65,6 +65,7 @@ func newRootCmd() *cobra.Command {
 	root.SetCompletionCommandGroupID(groupManage)
 	root.AddCommand(
 		commandGroup(groupStart, newServeCmd()),
+		commandGroup(groupStart, newExecCmd()),
 		commandGroup(groupStart, newExposeCmd()),
 		commandGroup(groupObserve, newDashboardCmd()),
 		commandGroup(groupObserve, newRoutesCmd()),

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -23,6 +23,7 @@ type runSetupOpts struct {
 	server      string
 	token       string
 	clearClient bool
+	clearToken  bool
 }
 
 func newSetupCmd() *cobra.Command {
@@ -52,7 +53,8 @@ func newSetupCmd() *cobra.Command {
 			"After local setup, you'll be asked for a public server and token\n" +
 			"so `expose` needs no flags later. The server defaults to\n" +
 			"https://edge.routeup.dev — press Enter to accept, or type 'none' to\n" +
-			"stay local. Pass --server/--token to skip those questions.\n\n" +
+			"stay local. At a saved token, press Enter to keep it or type 'none'\n" +
+			"to clear only the token. Pass --server/--token to skip those questions.\n\n" +
 			"Re-running setup is safe — it skips anything already done.",
 		Example: "  routeup setup                # the usual: HTTPS on port 443\n" +
 			"  routeup setup --port 8443    # use a high port (no password needed)\n" +
@@ -66,11 +68,15 @@ func newSetupCmd() *cobra.Command {
 				return fmt.Errorf("--no-bind requires --port 1024 or higher (got %d)", tlsPort)
 			}
 			clearClient := strings.EqualFold(strings.TrimSpace(server), "none")
+			clearToken := strings.EqualFold(strings.TrimSpace(token), "none")
 			if clearClient {
-				if strings.TrimSpace(token) != "" {
+				if strings.TrimSpace(token) != "" && !clearToken {
 					return errors.New("--server none cannot be combined with --token")
 				}
 				server = ""
+				token = ""
+				clearToken = false
+			} else if clearToken {
 				token = ""
 			}
 			return runSetup(cmd, runSetupOpts{
@@ -82,6 +88,7 @@ func newSetupCmd() *cobra.Command {
 				server:      server,
 				token:       token,
 				clearClient: clearClient,
+				clearToken:  clearToken,
 			})
 		},
 	}
@@ -92,7 +99,7 @@ func newSetupCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noBind, "no-bind", false, "skip port setup (requires --port 1024 or higher)")
 	cmd.Flags().BoolVar(&useSystem, "system", false, "macOS: force system-wide trust (automatic when binding a privileged port)")
 	cmd.Flags().StringVar(&server, "server", "", "public server URL to save for expose, or 'none' to clear saved credentials")
-	cmd.Flags().StringVar(&token, "token", "", "server token to save for expose")
+	cmd.Flags().StringVar(&token, "token", "", "server token to save for expose, or 'none' to clear the saved token")
 	return cmd
 }
 
@@ -171,7 +178,7 @@ func runSetup(cmd *cobra.Command, opts runSetupOpts) error {
 		}
 	}
 
-	if err := saveClientCreds(out, opts.server, opts.token, opts.clearClient); err != nil {
+	if err := saveClientCreds(out, opts.server, opts.token, opts.clearClient, opts.clearToken); err != nil {
 		return err
 	}
 

--- a/internal/cli/setup_credentials.go
+++ b/internal/cli/setup_credentials.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -14,7 +15,13 @@ import (
 	"github.com/mukul-mehta/routeup/internal/state"
 )
 
-const defaultPublicServer = "https://edge.routeup.dev"
+const (
+	defaultPublicServer = "https://edge.routeup.dev"
+	savedTokenMask      = "********"
+	maxTokenLength      = 4096
+)
+
+var errTokenPromptInterrupted = errors.New("token prompt interrupted")
 
 type serverCredPrompter struct {
 	in         *bufio.Reader
@@ -40,16 +47,15 @@ func promptServerCreds(cmd *cobra.Command, out io.Writer, opts *runSetupOpts) er
 		in:  bufio.NewReader(cmd.InOrStdin()),
 		out: out,
 		readSecret: func() (string, error) {
-			b, err := term.ReadPassword(int(os.Stdin.Fd()))
-			_, _ = fmt.Fprintln(out)
-			return string(b), err
+			return readMaskedSecret(os.Stdin, out)
 		},
 	}
 	return p.collect(cc, serverFromFlag, tokenFromFlag, opts)
 }
 
 // collect asks only for credentials not supplied by flags. Blank answers keep
-// saved values, while choosing "none" explicitly clears both fields.
+// saved values. Choosing "none" for the server clears both fields; choosing it
+// for the token clears only the token.
 func (p serverCredPrompter) collect(cc state.ClientConfig, serverFromFlag, tokenFromFlag bool, opts *runSetupOpts) error {
 	if !serverFromFlag {
 		styles := newTerminalStyles(p.out)
@@ -73,17 +79,28 @@ func (p serverCredPrompter) collect(cc state.ClientConfig, serverFromFlag, token
 	}
 
 	styles := newTerminalStyles(p.out)
+	hasSavedToken := cc.Token != "" && sameServer(cc.Server, opts.server)
+	promptSuffix := ", or press Enter to skip:"
+	if hasSavedToken {
+		promptSuffix = ". Press Enter to keep the saved token, or type 'none' to clear it:"
+	}
 	_, _ = fmt.Fprintf(p.out, "  %s%s%s\n",
 		styles.muted("Tokens authorize persistent public routes. Get one from "),
 		styles.url("https://routeup.dev"),
-		styles.muted(", or press Enter to skip:"),
+		styles.muted(promptSuffix),
 	)
-	tok, err := p.secret("  token")
+	tok, err := p.secret("  token", hasSavedToken)
 	if err != nil {
+		if errors.Is(err, errTokenPromptInterrupted) {
+			return err
+		}
 		_, _ = fmt.Fprintln(p.out, newTerminalStyles(p.out).warning(fmt.Sprintf("  (skipping token: %v)", err)))
 		return nil
 	}
-	if tok != "" {
+	if strings.EqualFold(tok, "none") {
+		opts.token = ""
+		opts.clearToken = true
+	} else if tok != "" {
 		opts.token = tok
 	} else if cc.Token != "" && sameServer(cc.Server, opts.server) {
 		opts.token = cc.Token
@@ -105,24 +122,100 @@ func (p serverCredPrompter) line(label, def string) string {
 	return def
 }
 
-func (p serverCredPrompter) secret(label string) (string, error) {
-	_, _ = fmt.Fprintf(p.out, "%s: ", newTerminalStyles(p.out).label(label))
+func (p serverCredPrompter) secret(label string, saved bool) (string, error) {
+	styles := newTerminalStyles(p.out)
+	if saved {
+		_, _ = fmt.Fprintf(p.out, "%s %s: ", styles.label(label), styles.muted("["+savedTokenMask+"]"))
+	} else {
+		_, _ = fmt.Fprintf(p.out, "%s: ", styles.label(label))
+	}
 	s, err := p.readSecret()
 	return strings.TrimSpace(s), err
 }
 
+func readMaskedSecret(in *os.File, out io.Writer) (string, error) {
+	fd := int(in.Fd())
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return "", fmt.Errorf("prepare token prompt: %w", err)
+	}
+
+	secret, readErr := readMaskedInput(in, out)
+	restoreErr := term.Restore(fd, oldState)
+	_, newlineErr := fmt.Fprintln(out)
+	if readErr != nil {
+		return "", readErr
+	}
+	if restoreErr != nil {
+		return "", fmt.Errorf("restore terminal after token prompt: %w", restoreErr)
+	}
+	if newlineErr != nil {
+		return "", fmt.Errorf("finish token prompt: %w", newlineErr)
+	}
+	return secret, nil
+}
+
+func readMaskedInput(in io.Reader, out io.Writer) (string, error) {
+	reader := bufio.NewReader(in)
+	secret := make([]rune, 0, 64)
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			return "", err
+		}
+
+		switch r {
+		case '\r', '\n':
+			return string(secret), nil
+		case '\x03':
+			return "", errTokenPromptInterrupted
+		case '\x04':
+			if len(secret) == 0 {
+				return "", io.EOF
+			}
+			return string(secret), nil
+		case '\b', '\x7f':
+			if len(secret) == 0 {
+				continue
+			}
+			secret = secret[:len(secret)-1]
+			if _, err := io.WriteString(out, "\b \b"); err != nil {
+				return "", fmt.Errorf("update token mask: %w", err)
+			}
+		case '\x15':
+			for range secret {
+				if _, err := io.WriteString(out, "\b \b"); err != nil {
+					return "", fmt.Errorf("clear token mask: %w", err)
+				}
+			}
+			secret = secret[:0]
+		default:
+			if unicode.IsControl(r) {
+				continue
+			}
+			if len(secret) >= maxTokenLength {
+				return "", errors.New("token is too long")
+			}
+			secret = append(secret, r)
+			if _, err := io.WriteString(out, "*"); err != nil {
+				return "", fmt.Errorf("write token mask: %w", err)
+			}
+		}
+	}
+}
+
 // saveClientCreds merges credentials without ever carrying a token to a
 // different server or allowing a token to exist without a server identity.
-func saveClientCreds(out io.Writer, server, token string, clear bool) error {
+func saveClientCreds(out io.Writer, server, token string, clearClient, clearToken bool) error {
 	styles := newTerminalStyles(out)
-	if clear {
+	if clearClient {
 		if err := state.WriteClientConfig(state.ClientConfig{}); err != nil {
 			return fmt.Errorf("clear server/token: %w", err)
 		}
 		_, _ = fmt.Fprintln(out, styles.stepOK("server/token", "cleared"))
 		return nil
 	}
-	if server == "" && token == "" {
+	if server == "" && token == "" && !clearToken {
 		return nil
 	}
 
@@ -142,6 +235,9 @@ func saveClientCreds(out io.Writer, server, token string, clear bool) error {
 		}
 		cc.Token = token
 	}
+	if clearToken {
+		cc.Token = ""
+	}
 	if err := state.WriteClientConfig(cc); err != nil {
 		return fmt.Errorf("save server/token: %w", err)
 	}
@@ -150,6 +246,8 @@ func saveClientCreds(out io.Writer, server, token string, clear bool) error {
 	}
 	if token != "" {
 		_, _ = fmt.Fprintln(out, styles.stepOK("token", "saved"))
+	} else if clearToken {
+		_, _ = fmt.Fprintln(out, styles.stepOK("token", "cleared"))
 	}
 	return nil
 }

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,7 +283,9 @@ func TestServerCredPrompter_Collect(t *testing.T) {
 		wantServer       string
 		wantToken        string
 		wantClear        bool
+		wantClearToken   bool
 		wantSecretCalled bool
+		wantSavedMask    bool
 		wantErr          string
 	}{
 		{
@@ -334,6 +337,17 @@ func TestServerCredPrompter_Collect(t *testing.T) {
 			wantServer:       "https://edge.routeup.dev",
 			wantToken:        "sk_saved",
 			wantSecretCalled: true,
+			wantSavedMask:    true,
+		},
+		{
+			name:             "none clears saved token but keeps server",
+			input:            "https://edge.routeup.dev\n",
+			secret:           "none",
+			cc:               state.ClientConfig{Server: "https://edge.routeup.dev", Token: "sk_saved"},
+			wantServer:       "https://edge.routeup.dev",
+			wantClearToken:   true,
+			wantSecretCalled: true,
+			wantSavedMask:    true,
 		},
 		{
 			name:             "blank token does not reuse token from another server",
@@ -375,9 +389,10 @@ func TestServerCredPrompter_Collect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			called := false
+			out := &bytes.Buffer{}
 			p := serverCredPrompter{
 				in:  bufio.NewReader(strings.NewReader(tt.input)),
-				out: &bytes.Buffer{},
+				out: out,
 				readSecret: func() (string, error) {
 					called = true
 					return tt.secret, nil
@@ -408,6 +423,83 @@ func TestServerCredPrompter_Collect(t *testing.T) {
 			if opts.clearClient != tt.wantClear {
 				t.Errorf("clear client = %v, want %v", opts.clearClient, tt.wantClear)
 			}
+			if opts.clearToken != tt.wantClearToken {
+				t.Errorf("clear token = %v, want %v", opts.clearToken, tt.wantClearToken)
+			}
+			if got := strings.Contains(out.String(), "["+savedTokenMask+"]"); got != tt.wantSavedMask {
+				t.Errorf("saved token mask present = %v, want %v\noutput: %s", got, tt.wantSavedMask, out)
+			}
+			if tt.wantSavedMask && !strings.Contains(out.String(), "Press Enter to keep the saved token, or type 'none' to clear it") {
+				t.Errorf("saved token prompt missing keep instruction: %s", out)
+			}
+			if tt.cc.Token != "" && strings.Contains(out.String(), tt.cc.Token) {
+				t.Errorf("saved token leaked to output: %s", out)
+			}
+		})
+	}
+}
+
+func TestReadMaskedInput(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantSecret string
+		wantOutput string
+		wantErr    error
+	}{
+		{
+			name:       "masks typed token",
+			input:      "sk_routeup\r",
+			wantSecret: "sk_routeup",
+			wantOutput: "**********",
+		},
+		{
+			name:       "backspace updates token and mask",
+			input:      "abc\x7fd\n",
+			wantSecret: "abd",
+			wantOutput: "***\b \b*",
+		},
+		{
+			name:       "control-u clears token and mask",
+			input:      "abc\x15d\n",
+			wantSecret: "d",
+			wantOutput: "***\b \b\b \b\b \b*",
+		},
+		{
+			name:       "control-c interrupts",
+			input:      "abc\x03",
+			wantOutput: "***",
+			wantErr:    errTokenPromptInterrupted,
+		},
+		{
+			name:       "control-d accepts typed token",
+			input:      "abc\x04",
+			wantSecret: "abc",
+			wantOutput: "***",
+		},
+		{
+			name:    "empty control-d returns EOF",
+			input:   "\x04",
+			wantErr: io.EOF,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			secret, err := readMaskedInput(strings.NewReader(tt.input), out)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if secret != tt.wantSecret {
+				t.Errorf("secret = %q, want %q", secret, tt.wantSecret)
+			}
+			if out.String() != tt.wantOutput {
+				t.Errorf("output = %q, want %q", out.String(), tt.wantOutput)
+			}
+			if tt.wantSecret != "" && strings.Contains(out.String(), tt.wantSecret) {
+				t.Errorf("secret leaked to output: %q", out.String())
+			}
 		})
 	}
 }
@@ -417,7 +509,7 @@ func TestSaveClientCredsDoesNotCarryTokenAcrossServers(t *testing.T) {
 	if err := state.WriteClientConfig(state.ClientConfig{Server: "https://old.example", Token: "sk_old"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := saveClientCreds(&bytes.Buffer{}, "https://new.example", "", false); err != nil {
+	if err := saveClientCreds(&bytes.Buffer{}, "https://new.example", "", false, false); err != nil {
 		t.Fatal(err)
 	}
 	config, err := state.ReadClientConfig()
@@ -428,7 +520,7 @@ func TestSaveClientCredsDoesNotCarryTokenAcrossServers(t *testing.T) {
 		t.Fatalf("client config = %#v, want new server without old token", config)
 	}
 
-	if err := saveClientCreds(&bytes.Buffer{}, "", "", true); err != nil {
+	if err := saveClientCreds(&bytes.Buffer{}, "", "", true, false); err != nil {
 		t.Fatal(err)
 	}
 	config, err = state.ReadClientConfig()
@@ -445,7 +537,7 @@ func TestSaveClientCredsClearsTokenWithoutServerIdentity(t *testing.T) {
 	if err := state.WriteClientConfig(state.ClientConfig{Token: "orphaned-token"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := saveClientCreds(&bytes.Buffer{}, "https://new.example", "", false); err != nil {
+	if err := saveClientCreds(&bytes.Buffer{}, "https://new.example", "", false, false); err != nil {
 		t.Fatal(err)
 	}
 	config, err := state.ReadClientConfig()
@@ -457,9 +549,49 @@ func TestSaveClientCredsClearsTokenWithoutServerIdentity(t *testing.T) {
 	}
 }
 
+func TestSaveClientCredsClearsOnlyToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := state.WriteClientConfig(state.ClientConfig{Server: "https://saved.example", Token: "sk_saved"}); err != nil {
+		t.Fatal(err)
+	}
+	out := &bytes.Buffer{}
+	if err := saveClientCreds(out, "", "", false, true); err != nil {
+		t.Fatal(err)
+	}
+	config, err := state.ReadClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Server != "https://saved.example" || config.Token != "" {
+		t.Fatalf("client config = %#v, want saved server without token", config)
+	}
+	if !strings.Contains(out.String(), "token") || !strings.Contains(out.String(), "cleared") {
+		t.Fatalf("output missing token cleared confirmation: %s", out)
+	}
+}
+
+func TestSetupTokenNoneClearsOnlyToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := state.WriteClientConfig(state.ClientConfig{Server: "https://saved.example", Token: "sk_saved"}); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newSetupCmd()
+	cmd.SetArgs([]string{"--no-start", "--no-trust", "--no-bind", "--port", "47443", "--token", "none"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	config, err := state.ReadClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Server != "https://saved.example" || config.Token != "" {
+		t.Fatalf("client config = %#v, want saved server without token", config)
+	}
+}
+
 func TestSaveClientCredsRejectsTokenWithoutServer(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	err := saveClientCreds(&bytes.Buffer{}, "", "orphaned-token", false)
+	err := saveClientCreds(&bytes.Buffer{}, "", "orphaned-token", false, false)
 	if err == nil || !strings.Contains(err.Error(), "requires a public server") {
 		t.Fatalf("error = %v, want missing server error", err)
 	}

--- a/internal/process/runner.go
+++ b/internal/process/runner.go
@@ -19,12 +19,14 @@ import (
 
 const defaultKillGrace = 10 * time.Second
 
-// Runner runs a single child command through the system shell.
+// Runner runs one child command. Command uses the system shell; Argv executes
+// an explicit argument vector without shell interpolation. Exactly one must be set.
 type Runner struct {
 	Command string
+	Argv    []string
 	Dir     string
 	Env     []string
-	// KillGrace is the delay before SIGKILL. Zero uses five seconds.
+	// KillGrace is the delay before SIGKILL. Zero uses ten seconds.
 	KillGrace time.Duration
 }
 
@@ -44,16 +46,15 @@ func (r Runner) Run(ctx context.Context, stdio Stdio) (code int, runErr error) {
 	if err := ctx.Err(); err != nil {
 		return 1, err
 	}
-	command := strings.TrimSpace(r.Command)
-	if command == "" {
-		return 1, errors.New("no command to run")
-	}
 	grace := r.KillGrace
 	if grace <= 0 {
 		grace = defaultKillGrace
 	}
 
-	cmd := exec.Command("sh", "-c", command)
+	cmd, err := r.execCommand()
+	if err != nil {
+		return 1, err
+	}
 	cmd.Dir = r.Dir
 	cmd.Env = r.Env
 	cmd.Stdin = stdio.In
@@ -131,6 +132,27 @@ func (r Runner) Run(ctx context.Context, stdio Stdio) (code int, runErr error) {
 			return exitCode(waitErr), nil
 		}
 	}
+}
+
+func (r Runner) execCommand() (*exec.Cmd, error) {
+	command := strings.TrimSpace(r.Command)
+	if command != "" && len(r.Argv) > 0 {
+		return nil, errors.New("set command or argv, not both")
+	}
+	if len(r.Argv) > 0 {
+		if strings.TrimSpace(r.Argv[0]) == "" {
+			return nil, errors.New("executable is required")
+		}
+		// The shell performs PATH lookup using the child's injected environment;
+		// "$@" preserves the explicit argument boundaries without interpolation.
+		args := []string{"-c", `exec "$@"`, "routeup-exec"}
+		args = append(args, r.Argv...)
+		return exec.Command("sh", args...), nil
+	}
+	if command == "" {
+		return nil, errors.New("no command to run")
+	}
+	return exec.Command("sh", "-c", command), nil
 }
 
 func signalProcessGroup(pid int, signal syscall.Signal) error {

--- a/internal/process/runner_test.go
+++ b/internal/process/runner_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net"
@@ -20,6 +21,42 @@ func TestRunner_ExitCode(t *testing.T) {
 	}
 	if code != 7 {
 		t.Fatalf("exit code = %d, want 7", code)
+	}
+}
+
+func TestRunner_ArgvExitCode(t *testing.T) {
+	code, err := Runner{Argv: []string{"sh", "-c", "exit 7"}}.Run(context.Background(), Stdio{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if code != 7 {
+		t.Fatalf("exit code = %d, want 7", code)
+	}
+}
+
+func TestRunner_RejectsCommandAndArgv(t *testing.T) {
+	_, err := Runner{Command: "true", Argv: []string{"true"}}.Run(context.Background(), Stdio{})
+	if err == nil || !strings.Contains(err.Error(), "not both") {
+		t.Fatalf("error = %v, want mutually exclusive command forms", err)
+	}
+}
+
+func TestRunner_ArgvUsesInjectedPATH(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "routeup-test-command")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nprintf injected-path"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	code, err := Runner{
+		Argv: []string{"routeup-test-command"},
+		Env:  []string{"PATH=" + dir},
+	}.Run(context.Background(), Stdio{Out: &out})
+	if err != nil || code != 0 {
+		t.Fatalf("Run = (%d, %v)", code, err)
+	}
+	if out.String() != "injected-path" {
+		t.Fatalf("output = %q, want injected-path", out.String())
 	}
 }
 

--- a/internal/proxy/local.go
+++ b/internal/proxy/local.go
@@ -157,7 +157,7 @@ func serveTargets(w http.ResponseWriter, r *http.Request, targets []route.Target
 	if !route.PathAllowed(exposedPaths, r.URL.Path) {
 		response.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		response.WriteHeader(http.StatusNotFound)
-		_, _ = io.WriteString(response, "routeup: path is not exposed\n")
+		_, _ = io.WriteString(response, "routeup: path does not exist or is not exposed\n")
 		return
 	}
 

--- a/internal/server/ingress_test.go
+++ b/internal/server/ingress_test.go
@@ -208,7 +208,7 @@ func TestIngress_PathTargetsAndExposePaths(t *testing.T) {
 	defer cleanup()
 
 	assertIngressBody(t, publicURL+"/api/ping", host, http.StatusOK, "api")
-	assertIngressBody(t, publicURL+"/", host, http.StatusNotFound, "routeup: path is not exposed\n")
+	assertIngressBody(t, publicURL+"/", host, http.StatusNotFound, "routeup: path does not exist or is not exposed\n")
 }
 
 func TestIngress_WebSocketHMR(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `routeup exec` for running commands with Routeup URLs and CA environment without registering a route
- Mask saved and entered setup tokens

## Testing

- `go test ./...`
- `golangci-lint run`
- Manually verified `routeup exec` with Zepl and local HTTPS