### PR TITLE
Add background execution to serve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist/
 /routeup
 /routeup.exe
+/dogfood-output/
 /.routeup-devel/
 
 # Test and coverage artifacts

--- a/PLAN.md
+++ b/PLAN.md
@@ -57,17 +57,15 @@ For local-only use, `routeup` never contacts a server and never needs a token. T
 Name resolution rule:
 
 ```txt
-Any argument containing a dot is taken literally:
+Any explicit route argument is taken literally:
+  routeup serve api             -> route api
   routeup serve api.myapp       -> route api.myapp
   routeup serve api.other       -> route api.other (no myapp scope)
 
-A bare name (no dots) is prefixed with the project name from config:
-  project = myapp
+Without an argument, the route comes from ROUTEUP_NAME, config name, or the
+working-directory basename:
+  config name = myapp
   routeup serve                 -> route myapp
-  routeup serve api             -> route api.myapp
-
-If no project is detected in scope, a bare name is used as-is:
-  routeup serve foo             -> route foo
 ```
 
 ## User Experience
@@ -82,6 +80,8 @@ routeup serve --port 8080
 routeup serve api --port 8080
 routeup serve api.myapp --port 9080
 routeup serve api.myapp --port 9080 --expose   # also expose publicly
+routeup serve api.myapp --port 9080 --detach   # keep serving in the background
+routeup stop api.myapp                         # stop a serve owner
 routeup expose api.myapp               # expose active or configured targets publicly
 routeup agent status
 routeup dashboard
@@ -255,13 +255,22 @@ For frontend + API behind one route, use path targets:
 
 The older `port` field remains shorthand for `{ "path": "/", "port": <port> }`.
 
-There is no separate "project" concept; the `name` field on the config is the project name used for bare-name resolution. Shared server and token settings live in `~/.routeup/client.json`, written by `routeup setup`, not in the per-service file.
+There is no separate "project" concept; the `name` field on the config is the
+default route when no explicit name is passed. Shared server and token settings
+live in `~/.routeup/client.json`, written by `routeup setup`, not in the
+per-service file.
 
 For isolated development and integration tests, `ROUTEUP_STATE_DIR` relocates
 the complete per-user state root (socket, PID, log, CA, setup marker, and client
 configuration) without changing `HOME`. It does not affect project config
 discovery. `ROUTEUP_AGENT_SOCKET` remains a socket-only override with higher
 precedence.
+
+Long-running CLI owners keep non-secret runtime identity records under the state
+root (`owners/`: route, owner kind, and PID only). These records do not persist
+targets, exposure configuration, or tokens. They let lifecycle commands
+distinguish an inactive route from a live owner temporarily restoring the
+in-memory agent after a restart.
 
 ## Exposure Model
 
@@ -486,14 +495,17 @@ The CLI should talk to the agent over a local socket. If the agent is not runnin
 Lifecycle ownership:
 
 ```txt
-The agent owns connections      tunnels and active proxy state
-The foreground CLI owns claims  route registrations, exposure, child processes
+The agent owns connections       tunnels and active proxy state
+Live CLI owners own desired state route registrations, exposure, child processes
 ```
 
 Foreground commands normally release their own registrations and exposures on
-exit. If one crashes, the agent reaps state owned by its dead PID and tears down
-matching connections. Other active claims and connections are unaffected. No
-`proxy start` or `proxy stop` style commands are exposed.
+exit. `serve --detach` re-execs a detached CLI owner with the same reconciliation
+behavior; `routeup stop <name>` asks that owner to exit through a live agent
+control stream rather than signaling a registry PID. If an owner crashes, the
+agent reaps state owned by its dead PID and tears down matching connections.
+Other active claims and connections are unaffected. No `proxy start` or `proxy
+stop` style commands are exposed.
 
 CLI-to-agent IPC:
 
@@ -648,6 +660,10 @@ routeup logs api.myapp --json
 routeup logs api.myapp --since 10m --method POST --status 202 --limit 50
 ```
 
+Foreground `routeup serve` follows new request records for its own route after
+printing readiness. `serve --json` keeps stdout to the single ready event;
+detached routes are followed explicitly with `routeup logs <route> --follow`.
+
 Default log line:
 
 ```txt
@@ -722,9 +738,10 @@ routeup uninstall  # remove agent, CA, certs, and state dir
 
 `routeup update` detects the install channel (Homebrew vs direct binary) and
 delegates to the appropriate updater. `routeup uninstall` must work even when
-the binary is being replaced: it stops the agent, removes the macOS port
-forwarder or Linux capability, removes the local CA from the trust store,
-deletes generated certificates, and removes `~/.routeup/`.
+the binary is being replaced: it cooperatively stops live serve owners, refuses
+to race an active runner or standalone exposure, stops the agent, removes the
+macOS port forwarder or Linux capability, removes the local CA from the trust
+store, deletes generated certificates, and removes `~/.routeup/`.
 
 ## Non-Goals For V1
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -267,8 +267,9 @@ discovery. `ROUTEUP_AGENT_SOCKET` remains a socket-only override with higher
 precedence.
 
 Long-running CLI owners keep non-secret runtime identity records under the state
-root (`owners/`: route, owner kind, and PID only). These records do not persist
-targets, exposure configuration, or tokens. They let lifecycle commands
+root (`owners/`: random record ID, route, owner kind, and PID). These records do not persist
+targets, exposure configuration, or tokens. Normal exits remove records;
+lifecycle checks prune records whose PID is dead. They let lifecycle commands
 distinguish an inactive route from a live owner temporarily restoring the
 in-memory agent after a restart.
 
@@ -501,7 +502,7 @@ Live CLI owners own desired state route registrations, exposure, child processes
 
 Foreground commands normally release their own registrations and exposures on
 exit. `serve --detach` re-execs a detached CLI owner with the same reconciliation
-behavior; `routeup stop <name>` asks that owner to exit through a live agent
+behavior; `routeup stop [name]` asks that owner to exit through a live agent
 control stream rather than signaling a registry PID. If an owner crashes, the
 agent reaps state owned by its dead PID and tears down matching connections.
 Other active claims and connections are unaffected. No `proxy start` or `proxy
@@ -653,7 +654,6 @@ routeup logs
 routeup logs myapp
 routeup logs api.myapp
 routeup logs api.myapp --follow
-routeup logs api.myapp --follow --plain
 routeup logs api.myapp --public
 routeup logs api.myapp --local
 routeup logs api.myapp --json
@@ -667,15 +667,15 @@ detached routes are followed explicitly with `routeup logs <route> --follow`.
 Default log line:
 
 ```txt
-12:41:03 public api.myapp POST /api/webhooks/github 200 38ms req_Ap7kQ3mN8vR2xLzC
-12:41:07 local  myapp     GET  /settings             200 12ms req_B9vL5rTs1mX8qK2d
+TIME      ROUTE                         SOURCE  STATUS  ID                    METHOD   DURATION  PATH
+12:41:03  api.myapp                     public  200     req_Ap7kQ3mN8vR2xLzC  POST     38ms      /api/webhooks/github
+12:41:07  myapp                         local   200     req_B9vL5rTs1mX8qK2d  GET      432us     /settings
 ```
 
-In an interactive terminal, `--follow` opens a Bubble Tea live viewer with a
-bounded 200-row display, scrolling, reconnect handling, and responsive columns.
-`--plain` forces append-only lines in a terminal, redirected output selects that
-format automatically, and `--json` writes NDJSON. Human terminal output uses
-Lip Gloss styling and honors `NO_COLOR`; machine output never contains ANSI
+`--follow` always writes append-only request rows; `--json` writes NDJSON. The
+full-screen reconnecting viewer is `routeup dashboard`, not `routeup logs`.
+Human rows use fixed-width columns and microsecond precision for sub-millisecond
+requests. Terminal output honors `NO_COLOR`; machine output never contains ANSI
 formatting.
 
 Request IDs are compact opaque values in `req_<16-char-random>` form. The log

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Detached mode keeps the same live ownership and agent-restart recovery as a
 foreground serve. `stop` releases the route and public exposure; it does not
 stop the external application listening on the target port.
 
+The stop name is optional and uses the same `ROUTEUP_NAME`, config-name, and
+directory fallback as `serve`. `routeup stop` controls only foreground or
+detached `serve` owners. Stop bare runner mode and standalone `routeup expose`
+from their owning terminal.
+
 Open an active route or emit machine-readable/QR output:
 
 ```bash
@@ -178,6 +183,10 @@ routeup expose --qr                     # public URL plus terminal QR code
 routeup expose --json                   # ready event for scripts/editors
 ```
 
+Standalone `expose` remains attached after printing readiness, including with
+`--json`, and restores its tunnel after agent restarts. Stop it with Ctrl-C in
+that terminal; `routeup stop` does not control standalone exposures.
+
 What you get depends on your token:
 
 ```txt
@@ -234,8 +243,9 @@ public: https://myapp.<your-namespace>.routeup.dev
 
 `ROUTEUP_LOCAL_URL` stays local. `ROUTEUP_URL` holds the public address. No
 second terminal needed — the tunnel releases with the process.
-Live owner commands, including detached `serve`, restore their route and public
-exposure if the local agent restarts or a tunnel terminates unexpectedly.
+Live owner commands, including detached `serve`, restore the local claim and/or
+public exposure they own if the local agent restarts or a tunnel terminates
+unexpectedly.
 
 ## Frontend + API
 
@@ -269,6 +279,10 @@ routeup logs myapp --follow          # append-only live request rows
 routeup logs myapp --public --json   # public traffic as JSON
 routeup logs myapp --since 10m --method POST --status 202 --limit 50
 ```
+
+Human request rows use fixed-width columns and clip overlong fields so the path
+column stays aligned. Sub-millisecond requests retain microsecond precision,
+such as `<1us`, `432us`, or `999us`, instead of rounding to `0ms`.
 
 Enable opt-in capture for webhook debugging:
 
@@ -315,8 +329,10 @@ routeup uninstall   # remove the CA, port-443 helper, and ~/.routeup
 
 `routes`, `doctor`, `agent status`, `config`, and `inspect` support `--json`.
 `logs --json` remains NDJSON and writes no human messages to stdout.
-`uninstall` stops live serve owners first and refuses to continue while a runner
-or standalone exposure command is still active.
+`uninstall` first checks runtime owners. It aborts while a runner or standalone
+exposure is active; stop that command in its terminal and retry. When all live
+owners are foreground or detached serve commands, uninstall stops them
+cooperatively before stopping the agent and removing setup state.
 
 `routeup dashboard` is read-only and requires an interactive terminal. Use Tab
 to move between routes, exposures, and requests; `j`/`k` to navigate; Enter to
@@ -413,6 +429,7 @@ scope. The web dashboard is deferred to a later release.
 - [x] Phase 7 — Path proxy
 - [x] Phase 8 — Local process runner
 - [x] Phase 8.5 — Runner exposure (`expose.enabled`; framework adapters out of scope)
+- [x] Phase 8.6 — Detached serve ownership and `routeup stop`
 - [x] Phase 9 — Route logs
 - [x] Phase 10 — Request capture & inspect
 - [x] Phase 11 — Public server rate limiting

--- a/README.md
+++ b/README.md
@@ -56,7 +56,24 @@ routeup serve myapp --port 3000      # https://myapp.localhost
 routeup serve api.myapp --port 8080  # https://api.myapp.localhost
 ```
 
-No config file needed for the basic case. Routes are named, stable, and trusted by the system CA.
+No config file needed for the basic case. Routes are named, stable, and trusted
+by the system CA. Foreground `serve` prints new local and public request logs for
+that route until Ctrl-C.
+
+An explicit name is always literal, even when the current directory has a
+different config name. Omit the name to use `ROUTEUP_NAME`, config `name`, or the
+working-directory basename.
+
+Keep a route running after the command returns, then stop it by name:
+
+```bash
+routeup serve myapp --port 3000 --detach  # shorthand: -d
+routeup stop myapp
+```
+
+Detached mode keeps the same live ownership and agent-restart recovery as a
+foreground serve. `stop` releases the route and public exposure; it does not
+stop the external application listening on the target port.
 
 Open an active route or emit machine-readable/QR output:
 
@@ -65,9 +82,9 @@ routeup serve myapp --port 3000 --json
 routeup serve myapp --port 3000 --qr
 ```
 
-`--json` writes one ready event after the route is usable. `--qr` prefers the
-public URL when exposure is enabled; a local `.localhost` QR only works on the
-machine running routeup.
+`--json` writes one ready event after the route is usable and does not mix live
+request rows into stdout. `--qr` prefers the public URL when exposure is
+enabled; a local `.localhost` QR only works on the machine running routeup.
 
 ## Runner mode
 
@@ -217,8 +234,8 @@ public: https://myapp.<your-namespace>.routeup.dev
 
 `ROUTEUP_LOCAL_URL` stays local. `ROUTEUP_URL` holds the public address. No
 second terminal needed — the tunnel releases with the process.
-Foreground commands restore their route and public exposure if the local agent
-restarts or a tunnel terminates unexpectedly.
+Live owner commands, including detached `serve`, restore their route and public
+exposure if the local agent restarts or a tunnel terminates unexpectedly.
 
 ## Frontend + API
 
@@ -248,8 +265,7 @@ go through the public tunnel.
 
 ```bash
 routeup logs myapp                   # recent traffic
-routeup logs myapp --follow          # interactive live viewer in a terminal
-routeup logs myapp --follow --plain  # append-only lines in a terminal
+routeup logs myapp --follow          # append-only live request rows
 routeup logs myapp --public --json   # public traffic as JSON
 routeup logs myapp --since 10m --method POST --status 202 --limit 50
 ```
@@ -290,6 +306,7 @@ contains terminal formatting.
 routeup dashboard   # interactive routes, exposures, live logs, and inspect
 routeup exec -- …   # run one command with the Routeup project environment
 routeup routes      # list active local routes (PUBLIC annotation when exposed)
+routeup stop myapp  # stop a foreground or detached serve owner
 routeup doctor      # check CA, OS trust, port 443, and agent health
 routeup config      # show the discovered file and resolved non-secret settings
 routeup update      # self-update (use brew upgrade for Homebrew installs)
@@ -298,6 +315,8 @@ routeup uninstall   # remove the CA, port-443 helper, and ~/.routeup
 
 `routes`, `doctor`, `agent status`, `config`, and `inspect` support `--json`.
 `logs --json` remains NDJSON and writes no human messages to stdout.
+`uninstall` stops live serve owners first and refuses to continue while a runner
+or standalone exposure command is still active.
 
 `routeup dashboard` is read-only and requires an interactive terminal. Use Tab
 to move between routes, exposures, and requests; `j`/`k` to navigate; Enter to
@@ -320,7 +339,7 @@ routeup completion fish > ~/.config/fish/completions/routeup.fish
 ```
 
 Subcommands and flags complete statically. When the agent is running,
-`routeup logs <Tab>` completes active route names and
+`routeup logs <Tab>` and `routeup stop <Tab>` complete active route names, and
 `routeup inspect <Tab>` completes captured request IDs.
 
 See [Shell completions](https://routeup.dev/docs/cli-reference/completion) for

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,6 +59,8 @@ routeup
 routeup serve
 routeup serve --port 8080
 routeup serve --port 8080 --expose
+routeup serve --port 8080 --detach
+routeup stop <name>
 routeup exec -- <command>
 routeup expose <name>
 routeup agent status
@@ -125,6 +127,9 @@ Agent API surface:
 POST   /v1/routes               register a route claim
 DELETE /v1/routes/{name}?owner_pid=  release a claim if ownership still matches
 GET    /v1/routes               list active routes
+GET    /v1/owners/{name}?owner_pid=  live cooperative owner-control stream
+POST   /v1/owners/{name}/stop        ask a connected serve owner to exit
+POST   /v1/owners/{name}/ack?owner_pid=  acknowledge stop receipt
 GET    /v1/status               agent status, boot id, and managed exposures
 POST   /v1/shutdown             graceful shutdown (used by `agent stop`/restart)
 GET    /v1/logs?route=&source=&method=&status=&since=&limit=&follow=  access-log list or SSE stream
@@ -134,14 +139,17 @@ POST   /v1/unexpose             stop public exposure
 ```
 
 The status response carries a `boot_id` generated once per agent process and a
-non-secret snapshot of managed public exposures. Foreground `serve`, `expose`,
-and runner commands retain their exact desired claim/exposure state. They
+non-secret snapshot of managed public exposures. Live `serve`, `expose`, and
+runner commands retain their exact desired claim/exposure state. They
 re-register and re-expose after an agent restart, and re-expose when a tunnel
 terminates permanently. Transient tunnel reconnects remain agent-owned and are
 reported as `reconnecting`, preventing duplicate sessions. Cleanup includes the
 owner PID so an old process cannot remove a replacement. This client-driven
 reconciliation keeps the registry and tunnel state in memory: live foreground
-commands are the source of truth.
+commands are the source of truth. `serve --detach` starts the same serve owner in
+a new session and returns only after its claim, optional exposure, and owner
+control stream are ready. `routeup stop` uses that stream, never a registry PID,
+so stale PID reuse cannot terminate an unrelated process.
 
 ### Request Logs (Phase 9) And Request Capture/Inspect (Phase 10)
 
@@ -614,18 +622,18 @@ route, allocate a port, or perform readiness checks. This lets one `routeup
 serve` process own a multi-target route while independently launched workers
 share its environment without making routeup their supervisor.
 
-Bare-name resolution:
+Route-name resolution:
 
 ```txt
-Any argument containing a dot is taken literally.
-A bare name is prefixed with the project name from the config.
-If no project name is set, a bare name is used as-is.
+Any explicit argument is taken literally.
+Without an argument, ROUTEUP_NAME overrides the config name.
+The working-directory basename is the final fallback.
 
-project = myapp (from routeup.json or package.json routeup.name)
+config name = myapp (from routeup.json or package.json routeup.name)
   routeup serve                 -> route myapp
-  routeup serve api             -> route api.myapp
+  routeup serve api             -> route api (literal)
   routeup serve api.myapp       -> route api.myapp (literal)
-  routeup serve api.other       -> route api.other (literal, not scoped under myapp)
+  routeup serve api.other       -> route api.other (literal)
 ```
 
 ## Process Lifecycle
@@ -666,6 +674,19 @@ For `routeup serve --port 8080 --expose`:
 8. CLI sends owner-conditional releases on exit.
 9. Agent tears down the tunnel for this route, leaving other tunnels unaffected.
 ```
+
+After readiness, foreground `serve` follows new request records for its route
+from the registration timestamp. SSE event IDs let it resume without replaying
+rows after an agent reconnect. `--json` preserves a ready-event-only stdout
+contract and does not start the implicit human log follower.
+
+`routeup serve --detach` resolves the same plan, passes it to a re-executed owner
+through inherited anonymous pipes, and waits for the child to report readiness.
+The token is not placed in argv, the environment, or a state file. The detached
+owner keeps `Maintain` and the owner-control stream alive; `routeup stop <name>`
+cooperatively cancels it and waits for owner-conditional cleanup. An active claim
+without a serve control stream, such as runner-owned state, fails closed instead
+of being signaled.
 
 Standalone `routeup expose <name>` starts the agent but does not register a
 local route. It reuses an active route's targets when one exists, otherwise it
@@ -729,6 +750,7 @@ trusted setup marker
 server URL
 token file
 agent socket path
+live CLI owner records (route, kind, PID only)
 bounded log store
 ```
 
@@ -741,6 +763,11 @@ remains the highest-precedence socket-only override; Linux uses
 `$XDG_RUNTIME_DIR/routeup/agent.sock` only when neither override is set.
 The `routeup-devel` build embeds its `.routeup-devel` state path at build time so it
 works directly from `PATH`; `ROUTEUP_STATE_DIR` can still override that default.
+The `owners/` directory contains one non-secret runtime identity record per live
+`serve`, runner, or standalone `expose` command. It is not desired-state
+persistence: records contain no targets or credentials and disappear when their
+owner exits. `stop` and `uninstall` use them to fail closed while the agent is
+between in-memory instances.
 
 The setup marker uses the initial version 1 format. `doctor` rejects missing or
 malformed markers, and macOS additionally validates that the installed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,7 @@ routeup serve
 routeup serve --port 8080
 routeup serve --port 8080 --expose
 routeup serve --port 8080 --detach
-routeup stop <name>
+routeup stop [name]
 routeup exec -- <command>
 routeup expose <name>
 routeup agent status
@@ -166,12 +166,12 @@ route, source, method, path/query, matched target when one exists, status, and
 duration. They disappear when the agent restarts. The current public server has
 no separate request-log store; `routeup logs` always reads from the agent.
 
-In a TTY, `routeup logs --follow` presents the stream through a full-screen
-Bubble Tea viewer. The viewer retains at most 200 rendered rows, deduplicates
-the snapshot after reconnecting, and clears stale rows when the agent boot ID
-changes. `--plain` forces line-oriented streaming in a terminal, redirected
-output selects it automatically, and `--json` writes NDJSON. All untrusted
-values are escaped before Lip Gloss styling is applied.
+`routeup logs --follow` writes append-only, line-oriented request rows.
+Redirected output uses the same format without terminal styling, and `--json`
+writes NDJSON. The full-screen request viewer and reconnect model belong to
+`routeup dashboard`; `logs` has no `--plain` flag. Human rows use fixed-width
+columns, clip overlong fields to preserve alignment, and retain microsecond
+precision below one millisecond. All untrusted values are escaped before styling.
 
 Phase 10 adds per-route opt-in request retention:
 
@@ -645,7 +645,7 @@ For `routeup` as a runner:
 2. CLI chooses a free app port and starts the local agent if needed.
 3. CLI reserves the local route.
 4. CLI starts the child process group with `PORT`, `HOST`, and local route URLs.
-5. CLI waits up to 15 seconds for the root target to accept connections.
+5. CLI waits up to 120 seconds for the root target to accept connections.
 6. CLI prints the ready route and waits for the child process group.
 7. CLI unregisters the route on exit or signal.
 8. After readiness, CLI exits with the child process exit code.
@@ -683,7 +683,7 @@ contract and does not start the implicit human log follower.
 `routeup serve --detach` resolves the same plan, passes it to a re-executed owner
 through inherited anonymous pipes, and waits for the child to report readiness.
 The token is not placed in argv, the environment, or a state file. The detached
-owner keeps `Maintain` and the owner-control stream alive; `routeup stop <name>`
+owner keeps `Maintain` and the owner-control stream alive; `routeup stop [name]`
 cooperatively cancels it and waits for owner-conditional cleanup. An active claim
 without a serve control stream, such as runner-owned state, fails closed instead
 of being signaled.
@@ -750,7 +750,7 @@ trusted setup marker
 server URL
 token file
 agent socket path
-live CLI owner records (route, kind, PID only)
+live CLI owner records (record ID, route, kind, PID)
 bounded log store
 ```
 
@@ -764,10 +764,12 @@ remains the highest-precedence socket-only override; Linux uses
 The `routeup-devel` build embeds its `.routeup-devel` state path at build time so it
 works directly from `PATH`; `ROUTEUP_STATE_DIR` can still override that default.
 The `owners/` directory contains one non-secret runtime identity record per live
-`serve`, runner, or standalone `expose` command. It is not desired-state
-persistence: records contain no targets or credentials and disappear when their
-owner exits. `stop` and `uninstall` use them to fail closed while the agent is
-between in-memory instances.
+`serve`, runner, or standalone `expose` command: random record ID, route, owner
+kind, and PID. It is not desired-state persistence and contains no targets,
+exposure configuration, or credentials. Normal exits remove records; lifecycle
+checks prune records whose PID is dead. PID reuse deliberately fails closed.
+`stop` and `uninstall` use these records while the agent is between in-memory
+instances.
 
 The setup marker uses the initial version 1 format. `doctor` rejects missing or
 malformed markers, and macOS additionally validates that the installed

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,7 +47,8 @@ curl https://myapp.localhost:47444/
 `just uninstall-devel` stops the isolated agent, removes the development CA from
 the trust store, deletes its state, and removes the `routeup-devel` binary. It
 never removes normal routeup trust, the global port helper, or Linux
-capabilities.
+capabilities. It refuses to proceed while a development runner or standalone
+exposure is active; stop that command in its terminal and retry.
 
 Override the defaults when parallel profiles or another port are needed:
 

--- a/docs/ENGINEERING-STANDARDS.md
+++ b/docs/ENGINEERING-STANDARDS.md
@@ -84,7 +84,9 @@ Avoid:
 - Pulling in a large config framework before the config model settles.
 - Supporting many equivalent config shapes for the same behavior.
 - Adding aliases for every command or field before users ask for them.
-- Inferring route names from the directory name or top-level package name.
+- Inferring route names from the top-level package name. The working-directory
+  basename is allowed only as the documented final fallback after an explicit
+  positional name, `ROUTEUP_NAME`, and config `name`.
 
 ## Networking Standards
 

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -571,6 +571,48 @@ package-manager lifecycle hook emulation
 framework-specific command adapters
 ```
 
+## Phase 8.6: Detached Serve Ownership
+
+Goal: make `routeup serve` useful in both foreground and background workflows
+without moving desired route state into persistent agent storage.
+
+> Implementation note: complete. Foreground `serve` follows new request logs
+> for its route after readiness. `serve -d/--detach` re-execs a detached owner,
+> passes its resolved plan and credentials through anonymous pipes, and returns
+> only after the claim, optional exposure, and cooperative owner-control stream
+> are ready. `routeup stop <name>` requests shutdown over that live stream and
+> never signals the PID reported by the route registry. Detached owners retain
+> the existing agent-restart and exposure reconciliation behavior. Non-secret
+> runtime owner records (route, kind, PID) let stop/uninstall distinguish an
+> inactive command from a live owner currently restoring the agent; targets and
+> credentials are never written there.
+
+Build:
+
+```txt
+foreground per-route request-log follow
+-d/--detach serve mode
+detached readiness handshake
+cooperative route owner control stream
+non-secret live owner identity records
+routeup stop [name]
+owner-conditional route and exposure cleanup
+```
+
+Acceptance:
+
+```bash
+routeup serve myapp --port 8080 --detach
+routeup agent restart
+curl https://myapp.localhost
+routeup stop myapp
+```
+
+The detached command exits only after the route is usable, the route survives
+an agent restart while its owner remains alive, and `stop` removes only that
+owner's route and optional exposure. Claims without a live serve control stream
+fail closed rather than receiving an OS signal.
+
 ## Phase 9: Route Logs
 
 Goal: make local and public traffic visible.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -580,10 +580,10 @@ without moving desired route state into persistent agent storage.
 > for its route after readiness. `serve -d/--detach` re-execs a detached owner,
 > passes its resolved plan and credentials through anonymous pipes, and returns
 > only after the claim, optional exposure, and cooperative owner-control stream
-> are ready. `routeup stop <name>` requests shutdown over that live stream and
+> are ready. `routeup stop [name]` requests shutdown over that live stream and
 > never signals the PID reported by the route registry. Detached owners retain
 > the existing agent-restart and exposure reconciliation behavior. Non-secret
-> runtime owner records (route, kind, PID) let stop/uninstall distinguish an
+> runtime owner records (record ID, route, kind, PID) let stop/uninstall distinguish an
 > inactive command from a live owner currently restoring the agent; targets and
 > credentials are never written there.
 
@@ -624,6 +624,8 @@ Goal: make local and public traffic visible.
 > bodies; request capture and inspect are implemented in Phase 10 below.
 > `--follow` always streams plain lines; `--json` emits NDJSON. The shared
 > Lip Gloss theme is also used by existing human-readable status commands.
+> Fixed-width human columns keep paths aligned, and sub-millisecond durations
+> retain microsecond precision instead of rounding to zero.
 
 Build:
 

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -168,9 +168,9 @@ occurs.
 
 `config.Resolve(inputs)` resolves a route name and target set by precedence:
 config targets/port, overridden by `ROUTEUP_PORT`, `--port`, and repeatable
-`--target /path=port`. Bare names are prefixed with the project name; dotted
-names are taken literally (`resolve.go`). `port` remains shorthand for the root
-`/` target.
+`--target /path=port`. Explicit positional names are literal; without one,
+`ROUTEUP_NAME`, config `name`, and the working-directory basename are consulted
+in that order (`resolve.go`). `port` remains shorthand for the root `/` target.
 
 Example M7 path-proxy config:
 
@@ -249,11 +249,15 @@ delivered directly to that group. Direct cancellation of routeup forwards the
 signal and escalates to SIGKILL after five seconds; an interactive child that
 ignores SIGINT cannot trigger that parent-side timer.
 
-The `serve` command (`serve.go`): resolves the route name and port, ensures the
-local CA exists, ensures the agent is running, registers the route claim with
-the agent, optionally calls `serveExpose` (same path as `expose`), then blocks
-on `Maintain` - a 2s desired-state loop that restores the claim and exposure
-after agent restart or terminal tunnel failure.
+The `serve` command (`serve.go`, `serve_owner.go`): resolves the route name and
+targets, ensures the local CA and agent exist, registers the route claim,
+optionally starts exposure, and runs `Maintain` - a 2s desired-state loop that
+restores the claim and exposure after agent restart or terminal tunnel failure.
+Foreground mode also follows new request logs for that route. `serve_detach.go`
+re-execs a hidden owner in a new session for `-d/--detach`, passing the complete
+plan through anonymous pipes and waiting for an explicit readiness response.
+`routeup stop` cooperatively cancels a connected serve owner through the agent;
+it does not signal the PID stored in the route registry.
 
 The `expose` command (`expose.go`): resolves server URL + token (flag > env >
 saved client config), resolves the route name, calls `startTunnel` which starts
@@ -308,8 +312,8 @@ type UnexposeRequest struct {
 }
 ```
 
-Path constants: `/v1/status`, `/v1/routes`, `/v1/logs`, `/v1/requests`,
-`/v1/shutdown`, `/v1/expose`, `/v1/unexpose`.
+Path constants: `/v1/status`, `/v1/routes`, `/v1/owners`, `/v1/logs`,
+`/v1/requests`, `/v1/shutdown`, `/v1/expose`, `/v1/unexpose`.
 
 ---
 
@@ -321,8 +325,9 @@ Created once per machine by `agentctl` when the CLI needs an agent. Key fields:
 
 ```go
 type Agent struct {
-    reg      *Registry       // in-memory route claims
-    tunnels  *tunnelManager  // M5: public tunnel sessions
+    reg      *Registry           // in-memory route claims
+    owners   *routeOwnerControls // live cooperative serve control streams
+    tunnels  *tunnelManager      // M5: public tunnel sessions
     sockPath string          // Unix socket for CLI IPC
     tlsAddr  string          // internal high-port TLS listener (127.0.0.1:47443); 443 reaches it post-setup
     bootID   string          // random, changes on every start (reconcile signal)
@@ -372,11 +377,14 @@ with public `expose.paths` filtering.
 
 ### API handlers (`api.go`)
 
-Nine endpoint forms over the Unix socket:
+Twelve endpoint forms over the Unix socket:
 
 - `POST /v1/routes` — register a claim
 - `DELETE /v1/routes/{name}` — unregister
 - `GET /v1/routes` — list claims
+- `GET /v1/owners/{name}` — attach a live serve-owner control stream
+- `POST /v1/owners/{name}/stop` — cooperatively ask that owner to exit
+- `POST /v1/owners/{name}/ack` — confirm the owner received that stop
 - `GET /v1/status` — agent status + boot ID
 - `GET /v1/logs` — metadata snapshot or SSE follow stream
 - `GET /v1/requests/{id}` — one retained exchange for inspection
@@ -392,8 +400,9 @@ The CLI stub that speaks to the agent over the Unix socket.
 
 ### Client (`client.go`)
 
-Wraps `http.Client` with a Unix-socket `DialContext`. Methods: `Status`,
-`Register`, `Unregister`, `List`, `Logs`, `FollowLogs`, and `Inspect`.
+Wraps `http.Client` with a Unix-socket `DialContext`. Methods include `Status`,
+`Register`, `Unregister`, `List`, `WatchRouteOwner`, `StopRoute`, `Logs`,
+`FollowLogs`, and `Inspect`.
 
 ### Lifecycle (`lifecycle.go`)
 
@@ -467,6 +476,10 @@ omitted names in inspect output.
 
 The API serves `GET /v1/logs` for a filtered finite metadata snapshot or
 `follow=true` SSE stream, and `GET /v1/requests/{id}` for one retained exchange.
+Each SSE row carries its request ID as the event ID, so a reconnecting follower
+can send `Last-Event-ID` and resume from the bounded ring without duplicating
+retained rows. Foreground `routeup serve` follows its route from the claim's
+agent-stamped registration time.
 `routeup logs` and `routeup inspect` only query an already-running agent; they do
 not start one because the ring is process-local. A request without capture
 returns a conflict from the inspect endpoint, while an evicted or unknown ID
@@ -510,6 +523,7 @@ Resolves filesystem paths under `~/.routeup/`:
 | `AgentSocketPath()` | `agent.sock` | CLI↔agent IPC |
 | `AgentLogPath()` | `agent.log` | Spawned agent stdout/stderr |
 | `AgentPIDPath()` | `agent.pid` | Running agent PID |
+| `RegisterOwner()` | `owners/*.json` | Non-secret live CLI owner identity |
 | `CACertPath()` | `ca.crt` | Local CA certificate |
 | `CAKeyPath()` | `ca.key` | Local CA private key |
 | `ReadClientConfig()` | `client.json` | Saved server URL + token |

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -40,6 +40,7 @@ internal/
   state/                   # Filesystem paths and state helpers
     constants.go           #   File/dir/env names
     paths.go               #   AgentSocketPath, CACertPath, etc.
+    owners.go              #   Non-secret owner leases and stale-record pruning
     setupmarker.go         #   Setup marker file
     clientconfig.go        #   ClientConfig (saved server URL + token)
 
@@ -48,6 +49,7 @@ internal/
 
   agentctl/                # CLI-side agent IPC client stub
     client.go              #   Client: Status, Register, Unregister, List
+    owners.go              #   Cooperative serve-owner watch, stop, and acknowledgment
     logs.go                #   Logs and FollowLogs
     inspect.go             #   Inspect one retained exchange
     lifecycle.go           #   EnsureRunning, Stop, Restart, spawnAndWait
@@ -113,6 +115,9 @@ internal/
     run_process.go         #   startup readiness and child result handling
     targets.go             #   target flag parsing and display
     serve.go               #   `routeup serve` — local + optional expose
+    serve_owner.go         #   shared foreground/detached lifecycle + live logs
+    serve_detach.go        #   detached re-exec and anonymous-pipe readiness
+    stop.go                #   `routeup stop` — cooperatively stop a serve owner
     expose.go              #   `routeup expose` — public tunnel only
     route_output.go        #   ready-event JSON and optional terminal QR output
     server.go              #   `routeup server` — run the public server
@@ -127,7 +132,7 @@ internal/
     config.go              #   resolved project configuration output
     routes.go              #   `routeup routes` — list active local routes (+ public)
     logs.go                #   `routeup logs` — metadata list and follow
-    logs_tui.go            #   Bubble Tea live request viewer and reconnect loop
+    logs_stream.go         #   dashboard live-log reconnect and responsive row formatting
     inspect.go              #   `routeup inspect` — retained exchange output
     terminal.go             #   safe escaping, TTY detection, and Lip Gloss theme
     update.go              #   `routeup update` — self update
@@ -209,6 +214,7 @@ routeup
   # user-facing
   setup                     One-time machine setup: local CA, OS trust, port 443
   serve [name]              Serve a local app on https://<name>.localhost (optionally --expose)
+  stop [name]               Stop a foreground or detached serve owner
   expose [name]             Expose a local port publicly through a routeup server
   routes                    List active local routes
   config                    Show resolved project configuration
@@ -229,7 +235,7 @@ routeup
   forward <from> <to>       TCP byte-pipe used by the macOS port-443 LaunchDaemon
 ```
 
-`server`, `token`, `agent run`, and `forward` are `Hidden: true` in cobra — real
+`server`, `token`, `serve-owner`, `agent run`, and `forward` are hidden Cobra commands — real
 commands, just kept out of `--help`. `server` and `token` are operator commands
 that open the server's database directly (the server need not be running).
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -41,6 +41,7 @@ type Options struct {
 // Agent is the local routeup daemon. New binds nothing; Run does the work.
 type Agent struct {
 	reg           *Registry
+	owners        *routeOwnerControls
 	logStore      *logs.Store
 	tunnels       *tunnelManager
 	sockPath      string
@@ -74,6 +75,7 @@ func New(opts Options) (*Agent, error) {
 
 	return &Agent{
 		reg:       NewRegistry(),
+		owners:    newRouteOwnerControls(),
 		logStore:  logs.NewStore(),
 		sockPath:  opts.SocketPath,
 		tlsAddr:   opts.TLSAddr,

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -18,6 +18,9 @@ func (a *Agent) apiHandler() http.Handler {
 	mux.HandleFunc("POST "+ipc.PathRoutes, a.handleRegister)
 	mux.HandleFunc("DELETE "+ipc.PathRoutes+"/{name}", a.handleUnregister)
 	mux.HandleFunc("GET "+ipc.PathRoutes, a.handleList)
+	mux.HandleFunc("GET "+ipc.PathOwners+"/{name}", a.handleOwnerEvents)
+	mux.HandleFunc("POST "+ipc.PathOwners+"/{name}/stop", a.handleStopOwner)
+	mux.HandleFunc("POST "+ipc.PathOwners+"/{name}/ack", a.handleOwnerStopAck)
 	mux.HandleFunc("GET "+ipc.PathLogs, a.handleLogs)
 	mux.HandleFunc("GET "+ipc.PathRequests+"/{id}", a.handleInspect)
 	mux.HandleFunc("GET "+ipc.PathStatus, a.handleStatus)
@@ -25,6 +28,111 @@ func (a *Agent) apiHandler() http.Handler {
 	mux.HandleFunc("POST "+ipc.PathExpose, a.handleExpose)
 	mux.HandleFunc("POST "+ipc.PathUnexpose, a.handleUnexpose)
 	return mux
+}
+
+func (a *Agent) handleOwnerEvents(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	ownerPID, err := strconv.Atoi(r.URL.Query().Get("owner_pid"))
+	if name == "" || err != nil || ownerPID <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "route name and valid owner_pid are required", nil)
+		return
+	}
+	claim, ok := a.reg.Lookup(name)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "route is not active", nil)
+		return
+	}
+	if claim.OwnerPID != ownerPID {
+		writeJSONError(w, http.StatusConflict, "route owner does not match", &claim)
+		return
+	}
+	control, ok := a.owners.attach(name, ownerPID)
+	if !ok {
+		writeJSONError(w, http.StatusConflict, "route owner control is already connected", &claim)
+		return
+	}
+	defer a.owners.detach(name, control)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSONError(w, http.StatusInternalServerError, "streaming response is unavailable", nil)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	_, _ = w.Write([]byte("event: ready\ndata: {}\n\n"))
+	flusher.Flush()
+
+	select {
+	case <-r.Context().Done():
+		return
+	case <-control.stop:
+		_, _ = w.Write([]byte("event: stop\ndata: {}\n\n"))
+		flusher.Flush()
+		select {
+		case <-r.Context().Done():
+		case <-control.ack:
+		}
+	}
+}
+
+func (a *Agent) handleStopOwner(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	claim, ok := a.reg.Lookup(name)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "route is not active", nil)
+		return
+	}
+	control := a.owners.stop(name, claim.OwnerPID)
+	if control == nil {
+		writeJSONError(w, http.StatusConflict,
+			"route owner cannot be stopped remotely; stop the holding process from its terminal", &claim)
+		return
+	}
+	acknowledged := false
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for !acknowledged {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-control.ack:
+			acknowledged = true
+		case <-ticker.C:
+			claim, active := a.reg.Lookup(name)
+			if !active || claim.OwnerPID != control.ownerPID {
+				writeJSON(w, http.StatusAccepted, map[string]string{"status": "stopped"})
+				return
+			}
+		}
+	}
+	for {
+		claim, active := a.reg.Lookup(name)
+		if !active || claim.OwnerPID != control.ownerPID {
+			writeJSON(w, http.StatusAccepted, map[string]string{"status": "stopped"})
+			return
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *Agent) handleOwnerStopAck(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	ownerPID, err := strconv.Atoi(r.URL.Query().Get("owner_pid"))
+	if name == "" || err != nil || ownerPID <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "route name and valid owner_pid are required", nil)
+		return
+	}
+	if !a.owners.acknowledge(name, ownerPID) {
+		writeJSONError(w, http.StatusConflict, "route owner control does not match", nil)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (a *Agent) handleRegister(w http.ResponseWriter, r *http.Request) {

--- a/internal/agent/logs.go
+++ b/internal/agent/logs.go
@@ -41,7 +41,7 @@ func (a *Agent) handleLogs(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	lastID := ""
+	lastID := r.Header.Get("Last-Event-ID")
 	first := true
 	for {
 		entries, changed := a.logStore.ListAndWatch(opts)
@@ -56,7 +56,7 @@ func (a *Agent) handleLogs(w http.ResponseWriter, r *http.Request) {
 				a.logger.Error("encode request log event", "err", err)
 				return
 			}
-			if _, err := fmt.Fprintf(w, "data: %s\n\n", body); err != nil {
+			if _, err := fmt.Fprintf(w, "id: %s\ndata: %s\n\n", entry.ID, body); err != nil {
 				return
 			}
 			lastID = entry.ID

--- a/internal/agent/logs_test.go
+++ b/internal/agent/logs_test.go
@@ -63,13 +63,7 @@ func TestHandleLogsFollowStreamsExistingAndNewEntries(t *testing.T) {
 	}
 
 	reader := bufio.NewReader(response.Body)
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(line, "data: ") {
-		t.Fatalf("event line = %q", line)
-	}
+	line := readSSEDataLine(t, reader)
 	if _, err := reader.ReadString('\n'); err != nil {
 		t.Fatal(err)
 	}
@@ -84,13 +78,7 @@ func TestHandleLogsFollowStreamsExistingAndNewEntries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	line, err = reader.ReadString('\n')
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(line, "data: ") {
-		t.Fatalf("event line = %q", line)
-	}
+	line = readSSEDataLine(t, reader)
 	if _, err := reader.ReadString('\n'); err != nil {
 		t.Fatal(err)
 	}
@@ -100,6 +88,19 @@ func TestHandleLogsFollowStreamsExistingAndNewEntries(t *testing.T) {
 	}
 	if newEntry.ID != "req_new" {
 		t.Fatalf("new event = %#v, want req_new", newEntry)
+	}
+}
+
+func readSSEDataLine(t *testing.T, reader *bufio.Reader) string {
+	t.Helper()
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(line, "data: ") {
+			return line
+		}
 	}
 }
 
@@ -118,6 +119,31 @@ func TestEntriesAfterResumesWhenCursorWasEvicted(t *testing.T) {
 	got := entriesAfter(entries, "req_evicted")
 	if len(got) != len(entries) || got[0].ID != entries[0].ID {
 		t.Fatalf("entriesAfter = %#v, want all retained entries", got)
+	}
+}
+
+func TestHandleLogsFollowResumesFromLastEventID(t *testing.T) {
+	a := &Agent{logStore: logs.NewStore(), logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	for _, id := range []string{"req_old", "req_new"} {
+		if _, err := a.logStore.Append(logs.Entry{ID: id, Route: "myapp", Source: logs.SourceLocal}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	server := httptest.NewServer(a.apiHandler())
+	defer server.Close()
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/v1/logs?follow=true", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Last-Event-ID", "req_old")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	line := readSSEDataLine(t, bufio.NewReader(response.Body))
+	if !strings.Contains(line, "req_new") || strings.Contains(line, "req_old") {
+		t.Fatalf("resumed event = %q", line)
 	}
 }
 

--- a/internal/agent/owners.go
+++ b/internal/agent/owners.go
@@ -1,0 +1,61 @@
+package agent
+
+import "sync"
+
+type routeOwnerControl struct {
+	ownerPID int
+	stop     chan struct{}
+	ack      chan struct{}
+	stopOnce sync.Once
+	ackOnce  sync.Once
+}
+
+type routeOwnerControls struct {
+	mu      sync.Mutex
+	byRoute map[string]*routeOwnerControl
+}
+
+func newRouteOwnerControls() *routeOwnerControls {
+	return &routeOwnerControls{byRoute: make(map[string]*routeOwnerControl)}
+}
+
+func (c *routeOwnerControls) attach(route string, ownerPID int) (*routeOwnerControl, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.byRoute[route]; exists {
+		return nil, false
+	}
+	control := &routeOwnerControl{ownerPID: ownerPID, stop: make(chan struct{}), ack: make(chan struct{})}
+	c.byRoute[route] = control
+	return control, true
+}
+
+func (c *routeOwnerControls) detach(route string, control *routeOwnerControl) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.byRoute[route] == control {
+		delete(c.byRoute, route)
+	}
+}
+
+func (c *routeOwnerControls) stop(route string, ownerPID int) *routeOwnerControl {
+	c.mu.Lock()
+	control := c.byRoute[route]
+	c.mu.Unlock()
+	if control == nil || control.ownerPID != ownerPID {
+		return nil
+	}
+	control.stopOnce.Do(func() { close(control.stop) })
+	return control
+}
+
+func (c *routeOwnerControls) acknowledge(route string, ownerPID int) bool {
+	c.mu.Lock()
+	control := c.byRoute[route]
+	c.mu.Unlock()
+	if control == nil || control.ownerPID != ownerPID {
+		return false
+	}
+	control.ackOnce.Do(func() { close(control.ack) })
+	return true
+}

--- a/internal/agent/owners_test.go
+++ b/internal/agent/owners_test.go
@@ -1,0 +1,149 @@
+package agent
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mukul-mehta/routeup/internal/ipc"
+	"github.com/mukul-mehta/routeup/internal/logs"
+	"github.com/mukul-mehta/routeup/internal/route"
+)
+
+func TestRouteOwnerControlStopsCooperatively(t *testing.T) {
+	a := newOwnerTestAgent(t)
+	server := httptest.NewServer(a.apiHandler())
+	defer server.Close()
+
+	eventsURL := server.URL + ipc.PathOwners + "/myapp?owner_pid=42"
+	response, err := http.Get(eventsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	reader := bufio.NewReader(response.Body)
+	if event := readOwnerEvent(t, reader); event != "ready" {
+		t.Fatalf("first event = %q, want ready", event)
+	}
+
+	stopResponse := make(chan *http.Response, 1)
+	stopErr := make(chan error, 1)
+	go func() {
+		response, postErr := http.Post(server.URL+ipc.PathOwners+"/myapp/stop", "application/json", nil)
+		stopResponse <- response
+		stopErr <- postErr
+	}()
+	if event := readOwnerEvent(t, reader); event != "stop" {
+		t.Fatalf("second event = %q, want stop", event)
+	}
+	ackResponse, err := http.Post(server.URL+ipc.PathOwners+"/myapp/ack?owner_pid=42", "application/json", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = ackResponse.Body.Close()
+	if ackResponse.StatusCode != http.StatusNoContent {
+		t.Fatalf("ack status = %d, want 204", ackResponse.StatusCode)
+	}
+	if !a.reg.Unregister("myapp", 42) {
+		t.Fatal("test owner did not unregister after acknowledging stop")
+	}
+	if err := <-stopErr; err != nil {
+		t.Fatal(err)
+	}
+	stopHTTPResponse := <-stopResponse
+	_ = stopHTTPResponse.Body.Close()
+	if stopHTTPResponse.StatusCode != http.StatusAccepted {
+		t.Fatalf("stop status = %d, want 202", stopHTTPResponse.StatusCode)
+	}
+}
+
+func TestStopOwnerFailsClosedWithoutControlStream(t *testing.T) {
+	a := newOwnerTestAgent(t)
+	request := httptest.NewRequest(http.MethodPost, ipc.PathOwners+"/myapp/stop", nil)
+	response := httptest.NewRecorder()
+	a.apiHandler().ServeHTTP(response, request)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", response.Code)
+	}
+	var body ipc.ErrorBody
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.OwnerPID != 42 || !strings.Contains(body.Error, "cannot be stopped remotely") {
+		t.Fatalf("error body = %#v", body)
+	}
+}
+
+func TestStopOwnerAcceptsIndependentOwnerCleanup(t *testing.T) {
+	a := newOwnerTestAgent(t)
+	server := httptest.NewServer(a.apiHandler())
+	defer server.Close()
+	response, err := http.Get(server.URL + ipc.PathOwners + "/myapp?owner_pid=42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	reader := bufio.NewReader(response.Body)
+	if event := readOwnerEvent(t, reader); event != "ready" {
+		t.Fatalf("first event = %q, want ready", event)
+	}
+
+	stopResponse := make(chan *http.Response, 1)
+	go func() {
+		result, _ := http.Post(server.URL+ipc.PathOwners+"/myapp/stop", "application/json", nil)
+		stopResponse <- result
+	}()
+	if event := readOwnerEvent(t, reader); event != "stop" {
+		t.Fatalf("second event = %q, want stop", event)
+	}
+	if !a.reg.Unregister("myapp", 42) {
+		t.Fatal("test owner did not unregister")
+	}
+	result := <-stopResponse
+	defer func() { _ = result.Body.Close() }()
+	if result.StatusCode != http.StatusAccepted {
+		t.Fatalf("stop status = %d, want 202", result.StatusCode)
+	}
+}
+
+func TestOwnerEventsRequireMatchingClaimOwner(t *testing.T) {
+	a := newOwnerTestAgent(t)
+	request := httptest.NewRequest(http.MethodGet, ipc.PathOwners+"/myapp?owner_pid=7", nil)
+	response := httptest.NewRecorder()
+	a.apiHandler().ServeHTTP(response, request)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", response.Code)
+	}
+}
+
+func newOwnerTestAgent(t *testing.T) *Agent {
+	t.Helper()
+	registry := NewRegistry()
+	if _, err := registry.Register(ipc.Claim{
+		Name: "myapp", Targets: []route.Target{{Path: "/", Port: 8080}}, OwnerPID: 42,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &Agent{
+		reg: registry, owners: newRouteOwnerControls(), logStore: logs.NewStore(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func readOwnerEvent(t *testing.T, reader *bufio.Reader) string {
+	t.Helper()
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(line, "event:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		}
+	}
+}

--- a/internal/agentctl/logs.go
+++ b/internal/agentctl/logs.go
@@ -35,11 +35,20 @@ func (c *Client) Logs(ctx context.Context, opts logs.ListOptions) ([]logs.Entry,
 // FollowLogs calls handle once for each existing and future matching entry. It
 // blocks until ctx is cancelled, the agent closes the stream, or handle fails.
 func (c *Client) FollowLogs(ctx context.Context, opts logs.ListOptions, handle func(logs.Entry) error) error {
+	return c.FollowLogsFrom(ctx, opts, "", handle)
+}
+
+// FollowLogsFrom resumes a request-log stream after lastID. The caller can
+// retain the latest handled entry ID and pass it back after reconnecting.
+func (c *Client) FollowLogsFrom(ctx context.Context, opts logs.ListOptions, lastID string, handle func(logs.Entry) error) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://unix"+logPath(opts, true), nil)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Accept", "text/event-stream")
+	if lastID != "" {
+		req.Header.Set("Last-Event-ID", lastID)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/agentctl/logs_test.go
+++ b/internal/agentctl/logs_test.go
@@ -126,6 +126,37 @@ func TestFollowLogsRejectsUnexpectedEOF(t *testing.T) {
 	}
 }
 
+func TestFollowLogsFromSendsLastEventID(t *testing.T) {
+	socketPath := filepath.Join(shortSocketDir(t), "agent.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Last-Event-ID"); got != "req_old" {
+			http.Error(w, "last event id = "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "id: req_new\ndata: {\"id\":\"req_new\"}\n\n")
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	})}
+	t.Cleanup(func() { _ = server.Close() })
+	go func() { _ = server.Serve(listener) }()
+
+	stop := errors.New("stop")
+	err = NewClient(socketPath, "", "").FollowLogsFrom(context.Background(), logs.ListOptions{}, "req_old", func(entry logs.Entry) error {
+		if entry.ID != "req_new" {
+			t.Fatalf("entry = %#v", entry)
+		}
+		return stop
+	})
+	if !errors.Is(err, stop) {
+		t.Fatalf("FollowLogsFrom error = %v, want stop", err)
+	}
+}
+
 func shortSocketDir(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "rup-")

--- a/internal/agentctl/owners.go
+++ b/internal/agentctl/owners.go
@@ -3,6 +3,7 @@ package agentctl
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/mukul-mehta/routeup/internal/ipc"
 )
+
+// ErrRouteOwnerControlUnavailable means the route is active but its serve owner
+// has not attached a cooperative control stream to the current agent yet.
+var ErrRouteOwnerControlUnavailable = errors.New("route owner cannot be stopped remotely; stop the holding process from its terminal")
 
 // WatchRouteOwner keeps a cooperative control stream open for a route owner.
 // onReady runs after the agent has attached the stream. stopped is true only
@@ -100,6 +105,10 @@ func (c *Client) StopRoute(ctx context.Context, name string) (found bool, err er
 	if resp.StatusCode == http.StatusNotFound {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return false, nil
+	}
+	if resp.StatusCode == http.StatusConflict {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return false, fmt.Errorf("agent: %w", ErrRouteOwnerControlUnavailable)
 	}
 	if resp.StatusCode != http.StatusAccepted {
 		return false, decodeErrorResponse(resp)

--- a/internal/agentctl/owners.go
+++ b/internal/agentctl/owners.go
@@ -1,0 +1,109 @@
+package agentctl
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mukul-mehta/routeup/internal/ipc"
+)
+
+// WatchRouteOwner keeps a cooperative control stream open for a route owner.
+// onReady runs after the agent has attached the stream. stopped is true only
+// when another CLI explicitly requested that this owner stop.
+func (c *Client) WatchRouteOwner(ctx context.Context, name string, ownerPID int, onReady func()) (stopped bool, err error) {
+	query := url.Values{"owner_pid": {fmt.Sprintf("%d", ownerPID)}}
+	path := ipc.PathOwners + "/" + url.PathEscape(name) + "?" + query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://unix"+path, nil)
+	if err != nil {
+		return false, fmt.Errorf("build route owner request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("agent unreachable at %s: %w", c.socketPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false, decodeErrorResponse(resp)
+	}
+	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		return false, fmt.Errorf("agent returned content type %q for route owner stream", resp.Header.Get("Content-Type"))
+	}
+
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
+			if readErr == io.EOF {
+				readErr = io.ErrUnexpectedEOF
+			}
+			return false, fmt.Errorf("read route owner stream: %w", readErr)
+		}
+		event := strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		if !strings.HasPrefix(line, "event:") {
+			continue
+		}
+		switch event {
+		case "ready":
+			if onReady != nil {
+				onReady()
+			}
+		case "stop":
+			if err := c.acknowledgeRouteStop(ctx, name, ownerPID); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+}
+
+func (c *Client) acknowledgeRouteStop(ctx context.Context, name string, ownerPID int) error {
+	query := url.Values{"owner_pid": {fmt.Sprintf("%d", ownerPID)}}
+	path := ipc.PathOwners + "/" + url.PathEscape(name) + "/ack?" + query.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://unix"+path, nil)
+	if err != nil {
+		return fmt.Errorf("build route stop acknowledgment: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("acknowledge route stop: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		return decodeErrorResponse(resp)
+	}
+	return nil
+}
+
+// StopRoute asks the live route owner to exit. It never sends an OS signal.
+// found is false when the route is not active.
+func (c *Client) StopRoute(ctx context.Context, name string) (found bool, err error) {
+	path := ipc.PathOwners + "/" + url.PathEscape(name) + "/stop"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://unix"+path, nil)
+	if err != nil {
+		return false, fmt.Errorf("build stop route request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("agent unreachable at %s: %w", c.socketPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return false, decodeErrorResponse(resp)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return true, nil
+}

--- a/internal/agentctl/owners_test.go
+++ b/internal/agentctl/owners_test.go
@@ -1,0 +1,65 @@
+package agentctl
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+)
+
+func TestClientWatchesAndStopsRouteOwner(t *testing.T) {
+	socketPath := filepath.Join(shortSocketDir(t), "agent.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := make(chan struct{})
+	ack := make(chan struct{})
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/owners/myapp":
+			if r.URL.Query().Get("owner_pid") != "42" {
+				http.Error(w, "wrong owner", http.StatusConflict)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, "event: ready\ndata: {}\n\n")
+			w.(http.Flusher).Flush()
+			<-stop
+			_, _ = fmt.Fprint(w, "event: stop\ndata: {}\n\n")
+			w.(http.Flusher).Flush()
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/owners/myapp/stop":
+			close(stop)
+			<-ack
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/owners/myapp/ack":
+			close(ack)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	})}
+	t.Cleanup(func() { _ = server.Close() })
+	go func() { _ = server.Serve(listener) }()
+
+	client := NewClient(socketPath, "", "")
+	ready := make(chan struct{})
+	watchDone := make(chan bool, 1)
+	go func() {
+		stopped, watchErr := client.WatchRouteOwner(context.Background(), "myapp", 42, func() { close(ready) })
+		if watchErr != nil {
+			t.Errorf("WatchRouteOwner: %v", watchErr)
+		}
+		watchDone <- stopped
+	}()
+	<-ready
+	found, err := client.StopRoute(context.Background(), "myapp")
+	if err != nil || !found {
+		t.Fatalf("StopRoute = %v, %v", found, err)
+	}
+	if stopped := <-watchDone; !stopped {
+		t.Fatal("owner stream ended without stop event")
+	}
+}

--- a/internal/agentctl/owners_test.go
+++ b/internal/agentctl/owners_test.go
@@ -2,6 +2,7 @@ package agentctl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -61,5 +62,27 @@ func TestClientWatchesAndStopsRouteOwner(t *testing.T) {
 	}
 	if stopped := <-watchDone; !stopped {
 		t.Fatal("owner stream ended without stop event")
+	}
+}
+
+func TestStopRouteClassifiesUnavailableOwnerControl(t *testing.T) {
+	socketPath := filepath.Join(shortSocketDir(t), "agent.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/owners/myapp/stop" {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		http.NotFound(w, r)
+	})}
+	t.Cleanup(func() { _ = server.Close() })
+	go func() { _ = server.Serve(listener) }()
+
+	_, err = NewClient(socketPath, "", "").StopRoute(context.Background(), "myapp")
+	if !errors.Is(err, ErrRouteOwnerControlUnavailable) {
+		t.Fatalf("StopRoute error = %v, want ErrRouteOwnerControlUnavailable", err)
 	}
 }

--- a/internal/cli/expose.go
+++ b/internal/cli/expose.go
@@ -126,6 +126,11 @@ func startTunnel(cmd *cobra.Command, serverURL, token, localRouteName, publicRou
 	}
 	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	ownerLease, err := state.RegisterOwner(localRouteName, state.OwnerExpose, os.Getpid())
+	if err != nil {
+		return fmt.Errorf("record expose owner: %w", err)
+	}
+	defer func() { _ = ownerLease.Release() }()
 
 	startCtx, cancelStart := context.WithTimeout(ctx, 10*time.Second)
 	defer cancelStart()

--- a/internal/cli/expose_test.go
+++ b/internal/cli/expose_test.go
@@ -68,8 +68,8 @@ func TestResolveExposeRoute(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.String() != "api.myapp" {
-		t.Fatalf("route = %q, want %q", got, "api.myapp")
+	if got.String() != "api" {
+		t.Fatalf("route = %q, want %q", got, "api")
 	}
 
 	if _, err := resolveExposeRoute("api..myapp", config.Config{}, false, ""); err == nil || !strings.Contains(err.Error(), "invalid route name") {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -203,7 +203,17 @@ func runLogs(cmd *cobra.Command, opts logs.ListOptions, commandOpts logsOpts) er
 
 func writeLogHeader(out io.Writer) error {
 	styles := newTerminalStyles(out)
-	_, err := fmt.Fprintln(out, styles.label("TIME      ROUTE                 SOURCE  STATUS  ID                    METHOD   DURATION  PATH"))
+	header := strings.Join([]string{
+		fitTerminalText("TIME", 8),
+		fitTerminalText("ROUTE", 28),
+		fitTerminalText("SOURCE", 6),
+		fitTerminalText("STATUS", 6),
+		fitTerminalText("ID", 20),
+		fitTerminalText("METHOD", 7),
+		fitTerminalText("DURATION", 8),
+		"PATH",
+	}, "  ")
+	_, err := fmt.Fprintln(out, styles.label(header))
 	if err != nil {
 		return fmt.Errorf("write request log header: %w", err)
 	}
@@ -218,20 +228,21 @@ func writeLogEntry(out io.Writer, entry logs.Entry, jsonOutput bool) error {
 		return nil
 	}
 	styles := newTerminalStyles(out)
-	source := fmt.Sprintf("%-6s", terminalEscapeString(string(entry.Source)))
+	source := fitTerminalText(terminalEscapeString(string(entry.Source)), 6)
 	if entry.Source == logs.SourcePublic {
 		source = styles.accent(source)
 	} else {
 		source = styles.muted(source)
 	}
-	routeName := styles.label(fmt.Sprintf("%-20s", terminalEscapeString(entry.Route)))
-	method := styles.label(fmt.Sprintf("%-7s", terminalEscapeString(entry.Method)))
-	requestPath := fmt.Sprintf("%-40s", terminalEscapeString(entry.RequestPath))
-	duration := styles.muted(fmt.Sprintf("%-8s", formatLogDuration(entry.Duration)))
-	status := styles.statusCode(entry.Status) + strings.Repeat(" ", max(0, 6-len(fmt.Sprintf("%d", entry.Status))))
+	routeName := styles.label(fitTerminalText(terminalEscapeString(entry.Route), 28))
+	method := styles.label(fitTerminalText(terminalEscapeString(entry.Method), 7))
+	requestPath := terminalEscapeString(entry.RequestPath)
+	duration := styles.muted(fitTerminalText(formatLogDuration(entry.Duration), 8))
+	status := fitTerminalText(styles.statusCode(entry.Status), 6)
+	id := styles.muted(fitTerminalText(terminalEscapeString(entry.ID), 20))
 	_, err := fmt.Fprintf(out, "%s  %s  %s  %s  %s  %s  %s  %s\n",
 		styles.muted(entry.StartedAt.Local().Format("15:04:05")), routeName, source,
-		status, styles.muted(fmt.Sprintf("%-20s", terminalEscapeString(entry.ID))), method, duration, requestPath)
+		status, id, method, duration, requestPath)
 	if err != nil {
 		return fmt.Errorf("write request log: %w", err)
 	}
@@ -239,8 +250,15 @@ func writeLogEntry(out io.Writer, entry logs.Entry, jsonOutput bool) error {
 }
 
 func formatLogDuration(duration time.Duration) string {
-	if duration < time.Millisecond {
+	if duration <= 0 {
 		return "0ms"
+	}
+	if duration < time.Millisecond {
+		microseconds := duration / time.Microsecond
+		if microseconds == 0 {
+			return "<1us"
+		}
+		return fmt.Sprintf("%dus", microseconds)
 	}
 	return duration.Round(time.Millisecond).String()
 }

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -55,9 +55,50 @@ func TestWriteLogHeader(t *testing.T) {
 	if err := writeLogHeader(&output); err != nil {
 		t.Fatal(err)
 	}
-	const want = "TIME      ROUTE                 SOURCE  STATUS  ID                    METHOD   DURATION  PATH\n"
+	const want = "TIME      ROUTE                         SOURCE  STATUS  ID                    METHOD   DURATION  PATH\n"
 	if output.String() != want {
 		t.Fatalf("header = %q, want %q", output.String(), want)
+	}
+}
+
+func TestWriteLogEntryKeepsColumnsAlignedForLongRoutes(t *testing.T) {
+	var header bytes.Buffer
+	if err := writeLogHeader(&header); err != nil {
+		t.Fatal(err)
+	}
+	entry := logs.Entry{
+		ID: "req_Ap7kQ3mN8vR2xLzC", StartedAt: time.Now(), Duration: 750 * time.Microsecond,
+		Source: logs.SourceLocal, Route: "a-route-name-that-is-far-too-long.example-app",
+		Method: http.MethodGet, RequestPath: "/routeup.json", Status: http.StatusOK,
+	}
+	var output bytes.Buffer
+	if err := writeLogEntry(&output, entry, false); err != nil {
+		t.Fatal(err)
+	}
+	sourceColumn := strings.Index(header.String(), "SOURCE")
+	if got := strings.Index(output.String(), "local"); got != sourceColumn {
+		t.Fatalf("source column starts at %d, want %d\nheader: %q\nentry:  %q", got, sourceColumn, header.String(), output.String())
+	}
+	if !strings.Contains(output.String(), "a-route-name-that-is-far-...") {
+		t.Fatalf("long route was not clipped predictably: %q", output.String())
+	}
+}
+
+func TestFormatLogDurationPreservesSubMillisecondPrecision(t *testing.T) {
+	tests := []struct {
+		duration time.Duration
+		want     string
+	}{
+		{0, "0ms"},
+		{500 * time.Nanosecond, "<1us"},
+		{432 * time.Microsecond, "432us"},
+		{999*time.Microsecond + 999*time.Nanosecond, "999us"},
+		{time.Millisecond, "1ms"},
+	}
+	for _, test := range tests {
+		if got := formatLogDuration(test.duration); got != test.want {
+			t.Errorf("formatLogDuration(%s) = %q, want %q", test.duration, got, test.want)
+		}
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -65,6 +65,7 @@ func newRootCmd() *cobra.Command {
 	root.SetCompletionCommandGroupID(groupManage)
 	root.AddCommand(
 		commandGroup(groupStart, newServeCmd()),
+		commandGroup(groupStart, newStopCmd()),
 		commandGroup(groupStart, newExecCmd()),
 		commandGroup(groupStart, newExposeCmd()),
 		commandGroup(groupObserve, newDashboardCmd()),
@@ -81,6 +82,7 @@ func newRootCmd() *cobra.Command {
 		commandGroup(groupManage, newForwardCmd()),
 		commandGroup(groupManage, newTokenCmd()),
 		commandGroup(groupManage, newServerCmd()),
+		commandGroup(groupManage, newServeOwnerCmd()),
 	)
 	return root
 }

--- a/internal/cli/route_output.go
+++ b/internal/cli/route_output.go
@@ -17,6 +17,8 @@ type routeReadyEvent struct {
 	PublicURL     string         `json:"public_url,omitempty"`
 	ExposurePaths []string       `json:"exposure_paths,omitempty"`
 	Targets       []route.Target `json:"targets"`
+	Detached      bool           `json:"detached,omitempty"`
+	OwnerPID      int            `json:"owner_pid,omitempty"`
 }
 
 func writeRouteReadyEvent(out io.Writer, event routeReadyEvent) error {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -72,6 +72,11 @@ func runRun(cmd *cobra.Command, cwd string) error {
 	}
 	ctx, stop := process.NotifyContext(parent)
 	defer stop()
+	ownerLease, err := state.RegisterOwner(routeName.String(), state.OwnerRunner, os.Getpid())
+	if err != nil {
+		return fmt.Errorf("record runner owner: %w", err)
+	}
+	defer func() { _ = ownerLease.Release() }()
 
 	startCtx, cancelStart := context.WithTimeout(ctx, 12*time.Second)
 	defer cancelStart()
@@ -106,7 +111,6 @@ func runRun(cmd *cobra.Command, cwd string) error {
 			_, _ = fmt.Fprintf(errOut, "routeup: unregister %q: %v\n", claim.Name, err)
 		}
 	}()
-
 	publicURL := ""
 	var exposeReq *ipc.ExposeRequest
 	if file.Expose.Enabled {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -8,16 +8,13 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/mukul-mehta/routeup/internal/agentctl"
 	"github.com/mukul-mehta/routeup/internal/certs"
 	"github.com/mukul-mehta/routeup/internal/config"
 	"github.com/mukul-mehta/routeup/internal/ipc"
 	"github.com/mukul-mehta/routeup/internal/route"
-	"github.com/mukul-mehta/routeup/internal/state"
 )
 
 type serveOpts struct {
@@ -29,6 +26,18 @@ type serveOpts struct {
 	token   string
 	json    bool
 	qr      bool
+	detach  bool
+}
+
+type servePlan struct {
+	Route           string             `json:"route"`
+	Targets         []route.Target     `json:"targets"`
+	CaptureRequest  bool               `json:"capture_request,omitempty"`
+	CaptureResponse bool               `json:"capture_response,omitempty"`
+	RedactHeaders   []string           `json:"redact_headers,omitempty"`
+	ExposurePaths   []string           `json:"exposure_paths,omitempty"`
+	Exposure        *ipc.ExposeRequest `json:"exposure,omitempty"`
+	CWD             string             `json:"cwd"`
 }
 
 func newServeCmd() *cobra.Command {
@@ -39,10 +48,10 @@ func newServeCmd() *cobra.Command {
 		Short: "Serve a local app on a stable HTTPS route",
 		Long: "Serve a local app on https://<name>.localhost.\n\n" +
 			"The route name comes from the argument, or from routeup.json or the\n" +
-			"package.json \"routeup\" block when omitted. A bare name is prefixed\n" +
-			"with the project name; a dotted name is taken literally:\n\n" +
+			"package.json \"routeup\" block when omitted. An explicit name is\n" +
+			"always taken literally:\n\n" +
 			"  serve example-app      ->  https://example-app.localhost\n" +
-			"  serve api              ->  https://api.<project>.localhost\n" +
+			"  serve api              ->  https://api.localhost\n" +
 			"  serve api.example-app  ->  https://api.example-app.localhost\n\n" +
 			"Add --expose, or set expose.enabled in config, to also publish it through\n" +
 			"a routeup server (the same as `routeup expose`); the public name is a\n" +
@@ -72,6 +81,7 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.token, "token", "", "with --expose, server token (or ROUTEUP_TOKEN, or saved by setup)")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "write the ready event as JSON")
 	cmd.Flags().BoolVar(&opts.qr, "qr", false, "print a QR code for the route URL")
+	cmd.Flags().BoolVarP(&opts.detach, "detach", "d", false, "keep the route running in the background")
 	cmd.MarkFlagsMutuallyExclusive("json", "qr")
 
 	return cmd
@@ -81,10 +91,34 @@ func runServe(cmd *cobra.Command, args []string, cwd string, opts serveOpts) err
 	if err := certs.EnsureLocalCA(); err != nil {
 		return err
 	}
-
-	discovered, err := config.Discover(cwd)
+	plan, err := resolveServePlan(args, cwd, opts)
 	if err != nil {
 		return err
+	}
+	if opts.detach {
+		event, err := startDetachedServe(cmd.Context(), cmd.Root().Version, plan)
+		if err != nil {
+			return err
+		}
+		event.Detached = true
+		return writeServeReady(cmd, event, opts)
+	}
+
+	parent := cmd.Context()
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return runServeOwner(ctx, cmd.Root().Version, plan, !opts.json, cmd.OutOrStdout(), cmd.ErrOrStderr(), func(event routeReadyEvent) error {
+		return writeServeReady(cmd, event, opts)
+	})
+}
+
+func resolveServePlan(args []string, cwd string, opts serveOpts) (servePlan, error) {
+	discovered, err := config.Discover(cwd)
+	if err != nil {
+		return servePlan{}, err
 	}
 
 	positional := ""
@@ -97,7 +131,7 @@ func runServe(cmd *cobra.Command, args []string, cwd string, opts serveOpts) err
 
 	targetFlags, err := parseTargetFlags(opts.targets)
 	if err != nil {
-		return err
+		return servePlan{}, err
 	}
 
 	resolved, err := config.Resolve(config.Inputs{
@@ -109,138 +143,44 @@ func runServe(cmd *cobra.Command, args []string, cwd string, opts serveOpts) err
 		DirName:        filepath.Base(cwd),
 	})
 	if err != nil {
-		return err
+		return servePlan{}, err
 	}
 
-	tlsPort := state.TLSPortOrDefault()
-	out := cmd.OutOrStdout()
-
-	sockPath, err := state.AgentSocketPath()
+	exposePaths, err := route.NormalizePathPatterns(discovered.Config.Expose.Paths)
 	if err != nil {
-		return err
+		return servePlan{}, err
 	}
-	client := agentctl.NewClient(sockPath, "", cmd.Root().Version)
-
-	parent := cmd.Context()
-	if parent == nil {
-		parent = context.Background()
-	}
-	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	startCtx, cancelStart := context.WithTimeout(ctx, 12*time.Second)
-	defer cancelStart()
-	ensured, err := client.EnsureRunning(startCtx)
-	if err != nil {
-		return fmt.Errorf("start agent: %w", err)
-	}
-	if ensured == agentctl.EnsureRestarted {
-		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "note: restarted the local agent to pick up a new build")
-	}
-
-	claim := ipc.Claim{
-		Name:            resolved.Route.String(),
-		Port:            resolved.Port,
+	plan := servePlan{
+		Route:           resolved.Route.String(),
 		Targets:         resolved.Targets,
 		CaptureRequest:  discovered.Config.Capture.Request,
 		CaptureResponse: discovered.Config.Capture.Response,
 		RedactHeaders:   discovered.Config.Capture.RedactHeaders,
-		OwnerPID:        os.Getpid(),
-		OwnerCWD:        cwd,
+		ExposurePaths:   exposePaths,
+		CWD:             cwd,
 	}
-
-	if _, err := client.Register(startCtx, claim); err != nil {
-		if _, ok := errors.AsType[*ipc.ConflictError](err); ok {
-			return fmt.Errorf("%w\n  hint: stop the holding process or pick a different route name", err)
-		}
-		return err
-	}
-
-	defer func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = client.Unregister(shutdownCtx, claim.Name, claim.OwnerPID)
-	}()
-
-	exposePaths, err := route.NormalizePathPatterns(discovered.Config.Expose.Paths)
-	if err != nil {
-		return err
-	}
-
-	var publicHost string
-	var exposeReq *ipc.ExposeRequest
 	if opts.expose || discovered.Config.Expose.Enabled {
-		host, request, stopExpose, err := serveExpose(ctx, client, resolved.Route, resolved.Targets, exposePaths, discovered.Config.Capture.Request, discovered.Config.Capture.Response, discovered.Config.Capture.RedactHeaders, opts)
+		serverURL, token, err := resolveServerToken(opts.server, opts.token)
 		if err != nil {
-			return err
+			return servePlan{}, err
 		}
-		defer stopExpose()
-		publicHost = host
-		exposeReq = &request
-	}
-
-	localRouteURL := localURL(resolved.Route.LocalHost(), tlsPort)
-	publicURL := ""
-	if publicHost != "" {
-		publicURL = "https://" + publicHost
-	}
-	if opts.json {
-		if err := writeRouteReadyEvent(out, routeReadyEvent{
-			Route: resolved.Route.String(), LocalURL: localRouteURL, PublicURL: publicURL,
-			ExposurePaths: exposePaths, Targets: resolved.Targets,
-		}); err != nil {
-			return err
+		if serverURL == "" {
+			return servePlan{}, errors.New("public exposure needs a server — pass --server, set ROUTEUP_SERVER, or run `routeup setup --server …`")
 		}
-	} else {
-		styles := newTerminalStyles(out)
-		_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("route:"), styles.accent(resolved.Route.String()))
-		_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("local:"), styles.url(localRouteURL))
-		if publicHost != "" {
-			_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("public:"), styles.url(publicURL))
-			_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("expose:"), formatExposePaths(exposePaths))
+		plan.Exposure = &ipc.ExposeRequest{
+			Name:            normalizePublicName(resolved.Route),
+			Route:           resolved.Route.String(),
+			Port:            resolved.Port,
+			Targets:         resolved.Targets,
+			Paths:           exposePaths,
+			CaptureRequest:  discovered.Config.Capture.Request,
+			CaptureResponse: discovered.Config.Capture.Response,
+			RedactHeaders:   discovered.Config.Capture.RedactHeaders,
+			Server:          serverURL,
+			Token:           token,
 		}
-		printTargets(out, resolved.Targets)
-		if opts.qr {
-			qrURL := localRouteURL
-			if publicURL != "" {
-				qrURL = publicURL
-			}
-			writeRouteQR(out, qrURL)
-		}
-		_, _ = fmt.Fprintln(out, "")
-		_, _ = fmt.Fprintln(out, styles.muted("press Ctrl-C to stop"))
 	}
-
-	client.Maintain(ctx, agentctl.DesiredState{
-		Claim: &claim, Exposure: exposeReq, PublicHost: publicHost,
-	}, cmd.ErrOrStderr())
-	return nil
-}
-
-func serveExpose(ctx context.Context, client *agentctl.Client, routeName route.Name, targets []route.Target, paths []string, captureRequest bool, captureResponse bool, redactHeaders []string, opts serveOpts) (string, ipc.ExposeRequest, func(), error) {
-	serverURL, token, err := resolveServerToken(opts.server, opts.token)
-	if err != nil {
-		return "", ipc.ExposeRequest{}, nil, err
-	}
-	if serverURL == "" {
-		return "", ipc.ExposeRequest{}, nil, errors.New("public exposure needs a server — pass --server, set ROUTEUP_SERVER, or run `routeup setup --server …`")
-	}
-
-	req := ipc.ExposeRequest{
-		Name:            normalizePublicName(routeName),
-		Route:           routeName.String(),
-		Port:            route.PrimaryPort(targets),
-		Targets:         targets,
-		Paths:           paths,
-		CaptureRequest:  captureRequest,
-		CaptureResponse: captureResponse,
-		RedactHeaders:   redactHeaders,
-		Server:          serverURL,
-		Token:           token,
-		OwnerPID:        os.Getpid(),
-	}
-	host, stop, err := holdExposure(ctx, client, req)
-	return host, req, stop, err
+	return plan, nil
 }
 
 func localURL(host string, port int) string {

--- a/internal/cli/serve_detach.go
+++ b/internal/cli/serve_detach.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mukul-mehta/routeup/internal/state"
+)
+
+const (
+	servePlanFD  = 3
+	serveReadyFD = 4
+)
+
+type detachedServeResult struct {
+	Ready *routeReadyEvent `json:"ready,omitempty"`
+	Error string           `json:"error,omitempty"`
+}
+
+func newServeOwnerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "serve-owner",
+		Short:  "(internal) hold a detached route",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			planFile := os.NewFile(servePlanFD, "routeup-serve-plan")
+			readyFile := os.NewFile(serveReadyFD, "routeup-serve-ready")
+			if planFile == nil || readyFile == nil {
+				return errors.New("detached serve pipes are unavailable")
+			}
+			defer func() { _ = planFile.Close() }()
+			defer func() { _ = readyFile.Close() }()
+
+			var plan servePlan
+			if err := json.NewDecoder(planFile).Decode(&plan); err != nil {
+				return fmt.Errorf("decode detached serve plan: %w", err)
+			}
+			encoder := json.NewEncoder(readyFile)
+			readySent := false
+			parent := cmd.Context()
+			if parent == nil {
+				parent = context.Background()
+			}
+			ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			err := runServeOwner(ctx, cmd.Root().Version, plan, false, readyFile, cmd.ErrOrStderr(), func(event routeReadyEvent) error {
+				if err := encoder.Encode(detachedServeResult{Ready: &event}); err != nil {
+					return fmt.Errorf("send detached serve readiness: %w", err)
+				}
+				readySent = true
+				return readyFile.Close()
+			})
+			if err != nil && !readySent {
+				_ = encoder.Encode(detachedServeResult{Error: err.Error()})
+			}
+			return err
+		},
+	}
+}
+
+func startDetachedServe(ctx context.Context, _ string, plan servePlan) (routeReadyEvent, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return routeReadyEvent{}, fmt.Errorf("locate routeup binary: %w", err)
+	}
+	planRead, planWrite, err := os.Pipe()
+	if err != nil {
+		return routeReadyEvent{}, fmt.Errorf("create detached serve plan pipe: %w", err)
+	}
+	defer func() { _ = planRead.Close() }()
+	defer func() { _ = planWrite.Close() }()
+	readyRead, readyWrite, err := os.Pipe()
+	if err != nil {
+		return routeReadyEvent{}, fmt.Errorf("create detached serve readiness pipe: %w", err)
+	}
+	defer func() { _ = readyRead.Close() }()
+	defer func() { _ = readyWrite.Close() }()
+
+	logPath, err := state.AgentLogPath()
+	if err != nil {
+		return routeReadyEvent{}, err
+	}
+	if err := state.EnsureParentDir(logPath); err != nil {
+		return routeReadyEvent{}, err
+	}
+	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return routeReadyEvent{}, fmt.Errorf("open detached serve log: %w", err)
+	}
+	defer func() { _ = logFile.Close() }()
+
+	child := exec.Command(exe, "serve-owner")
+	child.Dir = plan.CWD
+	child.Stdin = nil
+	child.Stdout = logFile
+	child.Stderr = logFile
+	child.ExtraFiles = []*os.File{planRead, readyWrite}
+	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	child.Env = withoutEnv(os.Environ(), "ROUTEUP_TOKEN")
+	if err := child.Start(); err != nil {
+		return routeReadyEvent{}, fmt.Errorf("start detached route owner: %w", err)
+	}
+	_ = planRead.Close()
+	_ = readyWrite.Close()
+	if err := json.NewEncoder(planWrite).Encode(plan); err != nil {
+		stopDetachedChild(child)
+		return routeReadyEvent{}, fmt.Errorf("send detached serve plan: %w", err)
+	}
+	_ = planWrite.Close()
+
+	resultCh := make(chan struct {
+		result detachedServeResult
+		err    error
+	}, 1)
+	go func() {
+		var result detachedServeResult
+		err := json.NewDecoder(readyRead).Decode(&result)
+		resultCh <- struct {
+			result detachedServeResult
+			err    error
+		}{result: result, err: err}
+	}()
+	waitCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	select {
+	case decoded := <-resultCh:
+		if decoded.err != nil {
+			stopDetachedChild(child)
+			return routeReadyEvent{}, fmt.Errorf("detached route owner exited before readiness: %w", decoded.err)
+		}
+		if decoded.result.Error != "" {
+			stopDetachedChild(child)
+			return routeReadyEvent{}, errors.New(decoded.result.Error)
+		}
+		if decoded.result.Ready == nil {
+			stopDetachedChild(child)
+			return routeReadyEvent{}, errors.New("detached route owner returned no readiness event")
+		}
+		_ = child.Process.Release()
+		return *decoded.result.Ready, nil
+	case <-waitCtx.Done():
+		_ = readyRead.Close()
+		stopDetachedChild(child)
+		return routeReadyEvent{}, fmt.Errorf("wait for detached route owner: %w", waitCtx.Err())
+	}
+}
+
+func withoutEnv(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		if len(entry) >= len(prefix) && entry[:len(prefix)] == prefix {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func stopDetachedChild(cmd *exec.Cmd) {
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+	}
+}

--- a/internal/cli/serve_owner.go
+++ b/internal/cli/serve_owner.go
@@ -1,0 +1,277 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mukul-mehta/routeup/internal/agentctl"
+	"github.com/mukul-mehta/routeup/internal/ipc"
+	"github.com/mukul-mehta/routeup/internal/logs"
+	"github.com/mukul-mehta/routeup/internal/route"
+	"github.com/mukul-mehta/routeup/internal/state"
+)
+
+func runServeOwner(ctx context.Context, version string, plan servePlan, followLogs bool, out, errOut io.Writer, ready func(routeReadyEvent) error) error {
+	sockPath, err := state.AgentSocketPath()
+	if err != nil {
+		return err
+	}
+	client := agentctl.NewClient(sockPath, "", version)
+	ownerCtx, cancelOwner := context.WithCancel(ctx)
+	defer cancelOwner()
+	ownerLease, err := state.RegisterOwner(plan.Route, state.OwnerServe, os.Getpid())
+	if err != nil {
+		return fmt.Errorf("record serve owner: %w", err)
+	}
+	defer func() { _ = ownerLease.Release() }()
+
+	startCtx, cancelStart := context.WithTimeout(ownerCtx, 12*time.Second)
+	ensured, err := client.EnsureRunning(startCtx)
+	cancelStart()
+	if err != nil {
+		return fmt.Errorf("start agent: %w", err)
+	}
+	if ensured == agentctl.EnsureRestarted {
+		_, _ = fmt.Fprintln(errOut, "note: restarted the local agent to pick up a new build")
+	}
+
+	claim := ipc.Claim{
+		Name:            plan.Route,
+		Port:            route.PrimaryPort(plan.Targets),
+		Targets:         plan.Targets,
+		CaptureRequest:  plan.CaptureRequest,
+		CaptureResponse: plan.CaptureResponse,
+		RedactHeaders:   plan.RedactHeaders,
+		OwnerPID:        os.Getpid(),
+		OwnerCWD:        plan.CWD,
+	}
+	registerCtx, cancelRegister := context.WithTimeout(ownerCtx, 5*time.Second)
+	registered, err := client.Register(registerCtx, claim)
+	cancelRegister()
+	if err != nil {
+		if _, ok := errors.AsType[*ipc.ConflictError](err); ok {
+			return fmt.Errorf("%w\n  hint: run `routeup stop %s`; non-serve owners must be stopped from their terminal", err, plan.Route)
+		}
+		return err
+	}
+	claim.RegisteredAt = registered.RegisteredAt
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = client.Unregister(shutdownCtx, claim.Name, claim.OwnerPID)
+	}()
+
+	publicHost := ""
+	var exposeReq *ipc.ExposeRequest
+	if plan.Exposure != nil {
+		request := *plan.Exposure
+		request.OwnerPID = claim.OwnerPID
+		host, stopExpose, exposeErr := holdExposure(ownerCtx, client, request)
+		if exposeErr != nil {
+			return exposeErr
+		}
+		defer stopExpose()
+		publicHost = host
+		exposeReq = &request
+	}
+
+	maintainDone := make(chan struct{})
+	go func() {
+		defer close(maintainDone)
+		client.Maintain(ownerCtx, agentctl.DesiredState{
+			Claim: &claim, Exposure: exposeReq, PublicHost: publicHost,
+		}, errOut)
+	}()
+
+	controlReady := make(chan struct{}, 1)
+	controlDone := make(chan bool, 1)
+	go func() {
+		controlDone <- maintainServeControl(ownerCtx, client, claim.Name, claim.OwnerPID, controlReady)
+	}()
+
+	controlTimer := time.NewTimer(12 * time.Second)
+	defer controlTimer.Stop()
+	select {
+	case <-controlReady:
+	case stopped := <-controlDone:
+		cancelOwner()
+		<-maintainDone
+		if stopped {
+			return errors.New("route stopped before becoming ready")
+		}
+		return ownerCtx.Err()
+	case <-controlTimer.C:
+		cancelOwner()
+		<-maintainDone
+		<-controlDone
+		return errors.New("route owner control did not become ready")
+	case <-ownerCtx.Done():
+		<-maintainDone
+		<-controlDone
+		return nil
+	}
+	routeName, err := route.Parse(plan.Route)
+	if err != nil {
+		cancelOwner()
+		<-maintainDone
+		<-controlDone
+		return err
+	}
+	publicURL := ""
+	if publicHost != "" {
+		publicURL = "https://" + publicHost
+	}
+	event := routeReadyEvent{
+		Route: plan.Route, LocalURL: localURL(routeName.LocalHost(), state.TLSPortOrDefault()),
+		PublicURL: publicURL, ExposurePaths: plan.ExposurePaths, Targets: plan.Targets,
+		OwnerPID: claim.OwnerPID,
+	}
+	if err := ready(event); err != nil {
+		cancelOwner()
+		<-maintainDone
+		<-controlDone
+		return err
+	}
+
+	var logsDone <-chan error
+	if followLogs {
+		ch := make(chan error, 1)
+		logsDone = ch
+		go func() {
+			ch <- followServeLogs(ownerCtx, client, logs.ListOptions{
+				Route: claim.Name, Since: registered.RegisteredAt,
+			}, out, errOut)
+		}()
+	}
+
+	var result error
+	controlFinished := false
+	logsFinished := false
+	select {
+	case <-ownerCtx.Done():
+	case <-controlDone:
+		controlFinished = true
+	case err := <-logsDone:
+		result = err
+		logsFinished = true
+	}
+	cancelOwner()
+	<-maintainDone
+	if !controlFinished {
+		<-controlDone
+	}
+	if logsDone != nil && !logsFinished {
+		select {
+		case err := <-logsDone:
+			if result == nil {
+				result = err
+			}
+		default:
+		}
+	}
+	return result
+}
+
+func maintainServeControl(ctx context.Context, client *agentctl.Client, name string, ownerPID int, ready chan<- struct{}) bool {
+	readySent := false
+	for {
+		stopped, err := client.WatchRouteOwner(ctx, name, ownerPID, func() {
+			if readySent {
+				return
+			}
+			readySent = true
+			select {
+			case ready <- struct{}{}:
+			default:
+			}
+		})
+		if stopped {
+			return true
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		_ = err
+		if !waitForFollowRetry(ctx) {
+			return false
+		}
+	}
+}
+
+type serveLogWriteError struct {
+	err error
+}
+
+func (e *serveLogWriteError) Error() string { return e.err.Error() }
+func (e *serveLogWriteError) Unwrap() error { return e.err }
+
+func followServeLogs(ctx context.Context, client *agentctl.Client, opts logs.ListOptions, out, errOut io.Writer) error {
+	lastID := ""
+	wroteHeader := false
+	for {
+		err := client.FollowLogsFrom(ctx, opts, lastID, func(entry logs.Entry) error {
+			if !wroteHeader {
+				if err := writeLogHeader(out); err != nil {
+					return &serveLogWriteError{err: err}
+				}
+				wroteHeader = true
+			}
+			if err := writeLogEntry(out, entry, false); err != nil {
+				return &serveLogWriteError{err: err}
+			}
+			lastID = entry.ID
+			return nil
+		})
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err != nil && !isTransientFollowError(err) {
+			var writeErr *serveLogWriteError
+			if errors.As(err, &writeErr) {
+				return writeErr.err
+			}
+			_, _ = fmt.Fprintf(errOut, "routeup: live request logs interrupted: %v; retrying\n", err)
+		}
+		if !waitForFollowRetry(ctx) {
+			return nil
+		}
+	}
+}
+
+func writeServeReady(cmd *cobra.Command, event routeReadyEvent, opts serveOpts) error {
+	out := cmd.OutOrStdout()
+	if opts.json {
+		return writeRouteReadyEvent(out, event)
+	}
+	styles := newTerminalStyles(out)
+	_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("route:"), styles.accent(event.Route))
+	_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("local:"), styles.url(event.LocalURL))
+	if event.PublicURL != "" {
+		_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("public:"), styles.url(event.PublicURL))
+		_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("expose:"), formatExposePaths(event.ExposurePaths))
+	}
+	printTargets(out, event.Targets)
+	if opts.qr {
+		qrURL := event.LocalURL
+		if event.PublicURL != "" {
+			qrURL = event.PublicURL
+		}
+		writeRouteQR(out, qrURL)
+	}
+	_, _ = fmt.Fprintln(out)
+	if event.Detached {
+		_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("status:"), styles.success(fmt.Sprintf("running in background (pid %d)", event.OwnerPID)))
+		_, _ = fmt.Fprintf(out, "%s routeup stop %s\n", styles.label("stop:"), event.Route)
+		_, _ = fmt.Fprintf(out, "%s routeup logs %s --follow\n", styles.label("logs:"), event.Route)
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "%s %s\n", styles.label("requests:"), styles.muted("live"))
+	_, _ = fmt.Fprintln(out, styles.muted("press Ctrl-C to stop"))
+	return nil
+}

--- a/internal/cli/serve_owner_test.go
+++ b/internal/cli/serve_owner_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mukul-mehta/routeup/internal/agentctl"
+	"github.com/mukul-mehta/routeup/internal/logs"
+)
+
+func TestFollowServeLogsFiltersFromRegistrationAndPrintsEntries(t *testing.T) {
+	since := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	querySeen := make(chan struct{}, 1)
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("route") != "myapp" || r.URL.Query().Get("since") != since.Format(time.RFC3339Nano) {
+			http.Error(w, "unexpected filters", http.StatusBadRequest)
+			return
+		}
+		querySeen <- struct{}{}
+		w.Header().Set("Content-Type", "text/event-stream")
+		entry := logs.Entry{
+			ID: "req_1234567890abcdef", Route: "myapp", Source: logs.SourceLocal,
+			Method: http.MethodGet, RequestPath: "/health", Status: http.StatusOK, StartedAt: since.Add(time.Second),
+		}
+		body, _ := json.Marshal(entry)
+		_, _ = w.Write([]byte("id: " + entry.ID + "\ndata: " + string(body) + "\n\n"))
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	client := agentctl.NewClient(socketPath, "", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	writer := &matchingWriter{match: "req_1234567890abcdef", matched: make(chan struct{}, 1)}
+	done := make(chan error, 1)
+	go func() {
+		done <- followServeLogs(ctx, client, logs.ListOptions{Route: "myapp", Since: since}, writer, writer)
+	}()
+	select {
+	case <-querySeen:
+	case <-t.Context().Done():
+		t.Fatal("serve log stream did not connect")
+	}
+	select {
+	case <-writer.matched:
+		cancel()
+	case <-t.Context().Done():
+		cancel()
+		t.Fatal("serve log stream did not print request")
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type matchingWriter struct {
+	match   string
+	matched chan struct{}
+}
+
+func (w *matchingWriter) Write(p []byte) (int, error) {
+	if strings.Contains(string(p), w.match) {
+		select {
+		case w.matched <- struct{}{}:
+		default:
+		}
+	}
+	return len(p), nil
+}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -58,18 +60,11 @@ func TestServeUsesExposureConfig(t *testing.T) {
 	t.Chdir(cwd)
 
 	var exposeCalls atomic.Int32
-	var statusCalls atomic.Int32
-	maintaining := make(chan struct{}, 1)
+	ownerReady := make(chan struct{}, 1)
 	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == ipc.PathStatus:
 			_ = json.NewEncoder(w).Encode(ipc.Status{BootID: "boot"})
-			if statusCalls.Add(1) >= 2 {
-				select {
-				case maintaining <- struct{}{}:
-				default:
-				}
-			}
 		case r.Method == http.MethodPost && r.URL.Path == ipc.PathRoutes:
 			var claim ipc.Claim
 			_ = json.NewDecoder(r.Body).Decode(&claim)
@@ -80,6 +75,10 @@ func TestServeUsesExposureConfig(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == ipc.PathExpose:
 			exposeCalls.Add(1)
 			_ = json.NewEncoder(w).Encode(ipc.ExposeResponse{Host: "myapp.example"})
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathOwners+"/myapp":
+			writeOwnerReady(w, r, ownerReady)
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathLogs:
+			writeEmptyLogStream(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -96,7 +95,7 @@ func TestServeUsesExposureConfig(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- cmd.Execute() }()
 	select {
-	case <-maintaining:
+	case <-ownerReady:
 		cancel()
 	case <-t.Context().Done():
 		cancel()
@@ -120,18 +119,11 @@ func TestServeJSONWritesOnlyReadyEvent(t *testing.T) {
 	}
 	t.Chdir(cwd)
 
-	var statusCalls atomic.Int32
-	maintaining := make(chan struct{}, 1)
+	outputWritten := make(chan struct{}, 1)
 	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == ipc.PathStatus:
 			_ = json.NewEncoder(w).Encode(ipc.Status{BootID: "boot"})
-			if statusCalls.Add(1) >= 2 {
-				select {
-				case maintaining <- struct{}{}:
-				default:
-				}
-			}
 		case r.Method == http.MethodPost && r.URL.Path == ipc.PathRoutes:
 			var claim ipc.Claim
 			_ = json.NewDecoder(r.Body).Decode(&claim)
@@ -139,6 +131,8 @@ func TestServeJSONWritesOnlyReadyEvent(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(claim)
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, ipc.PathRoutes+"/"):
 			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathOwners+"/myapp":
+			writeOwnerReady(w, r, nil)
 		default:
 			http.NotFound(w, r)
 		}
@@ -149,13 +143,13 @@ func TestServeJSONWritesOnlyReadyEvent(t *testing.T) {
 	cmd := newRootCmd()
 	cmd.SetContext(ctx)
 	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
+	cmd.SetOut(signalWriter{Writer: &stdout, written: outputWritten})
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{"serve", "--json"})
 	done := make(chan error, 1)
 	go func() { done <- cmd.Execute() }()
 	select {
-	case <-maintaining:
+	case <-outputWritten:
 		cancel()
 	case <-t.Context().Done():
 		cancel()
@@ -174,4 +168,37 @@ func TestServeJSONWritesOnlyReadyEvent(t *testing.T) {
 	if strings.Contains(stdout.String(), "press Ctrl-C") {
 		t.Fatalf("JSON output contains human text: %s", stdout.String())
 	}
+}
+
+func writeOwnerReady(w http.ResponseWriter, r *http.Request, ready chan<- struct{}) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = fmt.Fprint(w, "event: ready\ndata: {}\n\n")
+	w.(http.Flusher).Flush()
+	if ready != nil {
+		select {
+		case ready <- struct{}{}:
+		default:
+		}
+	}
+	<-r.Context().Done()
+}
+
+type signalWriter struct {
+	io.Writer
+	written chan<- struct{}
+}
+
+func (w signalWriter) Write(p []byte) (int, error) {
+	n, err := w.Writer.Write(p)
+	select {
+	case w.written <- struct{}{}:
+	default:
+	}
+	return n, err
+}
+
+func writeEmptyLogStream(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.(http.Flusher).Flush()
+	<-r.Context().Done()
 }

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mukul-mehta/routeup/internal/agentctl"
+	"github.com/mukul-mehta/routeup/internal/config"
+	"github.com/mukul-mehta/routeup/internal/state"
+)
+
+func newStopCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop [name]",
+		Short: "Stop a routeup serve owner",
+		Long: "Stop an active route held by `routeup serve`, including a detached route.\n\n" +
+			"This releases the local route and public exposure. It does not stop the\n" +
+			"external application listening on the target port.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting cwd: %w", err)
+			}
+			return runStop(cmd, args, cwd)
+		},
+	}
+	cmd.ValidArgsFunction = completeActiveRoutes
+	return cmd
+}
+
+func runStop(cmd *cobra.Command, args []string, cwd string) error {
+	discovered, err := config.Discover(cwd)
+	if err != nil {
+		return err
+	}
+	positional := ""
+	if len(args) == 1 {
+		positional = args[0]
+	}
+	name, err := config.ResolveName(config.Inputs{
+		PositionalName: positional,
+		Env:            os.Getenv,
+		File:           discovered.Config,
+		DirName:        filepath.Base(cwd),
+	})
+	if err != nil {
+		return err
+	}
+	socketPath, err := state.AgentSocketPath()
+	if err != nil {
+		return err
+	}
+	client := agentctl.NewClient(socketPath, "", cmd.Root().Version)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 85*time.Second)
+	defer cancel()
+	found, err := stopRouteAfterReconcile(ctx, client, name.String(), 75*time.Second)
+	out := cmd.OutOrStdout()
+	styles := newTerminalStyles(out)
+	if agentctl.IsUnavailable(err) {
+		_, _ = fmt.Fprintf(out, "%s %s\n", styles.muted("route not active:"), name.String())
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stop route %q: %w", name.String(), err)
+	}
+	if !found {
+		_, _ = fmt.Fprintf(out, "%s %s\n", styles.muted("route not active:"), name.String())
+		return nil
+	}
+	if err := waitForRouteStop(ctx, client, name.String()); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "%s %s\n", styles.success("route stopped:"), name.String())
+	return nil
+}
+
+func stopRouteAfterReconcile(ctx context.Context, client *agentctl.Client, name string, budget time.Duration) (bool, error) {
+	deadline := time.Now().Add(budget)
+	for {
+		found, err := client.StopRoute(ctx, name)
+		if err == nil && found {
+			return true, nil
+		}
+		if err != nil && !agentctl.IsUnavailable(err) {
+			return false, err
+		}
+		live, ownerErr := hasLiveServeOwner(name)
+		if ownerErr != nil {
+			return false, ownerErr
+		}
+		if !live {
+			return false, nil
+		}
+		if time.Now().After(deadline) {
+			return false, fmt.Errorf("serve owner for route %q is alive but its agent control is unavailable", name)
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+func hasLiveServeOwner(name string) (bool, error) {
+	owners, err := state.LiveOwners()
+	if err != nil {
+		return false, fmt.Errorf("read route owner state: %w", err)
+	}
+	for _, owner := range owners {
+		if owner.Route == name && owner.Kind == state.OwnerServe {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func waitForRouteStop(ctx context.Context, client *agentctl.Client, name string) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		claims, err := client.List(ctx)
+		if err != nil {
+			if agentctl.IsUnavailable(err) {
+				return nil
+			}
+			return fmt.Errorf("verify route stopped: %w", err)
+		}
+		active := false
+		for _, claim := range claims {
+			if claim.Name == name {
+				active = true
+				break
+			}
+		}
+		if !active {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("route %q did not stop: %w", name, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func completeActiveRoutes(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	socketPath, err := state.AgentSocketPath()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	client := agentctl.NewClient(socketPath, "", cmd.Root().Version)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	claims, err := client.List(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	names := make([]string, 0, len(claims))
+	for _, claim := range claims {
+		names = append(names, claim.Name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -87,7 +88,8 @@ func stopRouteAfterReconcile(ctx context.Context, client *agentctl.Client, name 
 		if err == nil && found {
 			return true, nil
 		}
-		if err != nil && !agentctl.IsUnavailable(err) {
+		controlUnavailable := errors.Is(err, agentctl.ErrRouteOwnerControlUnavailable)
+		if err != nil && !agentctl.IsUnavailable(err) && !controlUnavailable {
 			return false, err
 		}
 		live, ownerErr := hasLiveServeOwner(name)
@@ -95,6 +97,9 @@ func stopRouteAfterReconcile(ctx context.Context, client *agentctl.Client, name 
 			return false, ownerErr
 		}
 		if !live {
+			if controlUnavailable {
+				return false, err
+			}
 			return false, nil
 		}
 		if time.Now().After(deadline) {

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mukul-mehta/routeup/internal/ipc"
+	"github.com/mukul-mehta/routeup/internal/state"
+)
+
+func TestStopRouteResolvesBareNameAndWaitsForRemoval(t *testing.T) {
+	cwd := t.TempDir()
+	writeConfig(t, cwd, `{"name":"myapp","port":8080}`)
+	t.Chdir(cwd)
+	var active atomic.Bool
+	active.Store(true)
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == ipc.PathOwners+"/api/stop":
+			active.Store(false)
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathRoutes:
+			routes := []ipc.Claim{}
+			if active.Load() {
+				routes = append(routes, ipc.Claim{Name: "api", OwnerPID: 42})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"routes": routes})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Setenv("ROUTEUP_AGENT_SOCKET", socketPath)
+	stdout, _, err := runRoot(t, "stop", "api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "route stopped:") || !strings.Contains(stdout, "api") {
+		t.Fatalf("output = %q", stdout)
+	}
+}
+
+func TestStopRouteFailsClosedForUncontrolledOwner(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == ipc.PathOwners+"/myapp/stop" {
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(ipc.ErrorBody{Error: "route owner cannot be stopped remotely", OwnerPID: 42})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Setenv("ROUTEUP_AGENT_SOCKET", socketPath)
+	_, _, err := runRoot(t, "stop", "myapp")
+	if err == nil || !strings.Contains(err.Error(), "cannot be stopped remotely") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestStopRouteWaitsForOwnerToReconcileAfterAgentRestart(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	t.Setenv(state.StateDirEnv, t.TempDir())
+	lease, err := state.RegisterOwner("myapp", state.OwnerServe, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	var stopCalls atomic.Int32
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == ipc.PathOwners+"/myapp/stop":
+			if stopCalls.Add(1) < 3 {
+				http.NotFound(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathStatus:
+			_ = json.NewEncoder(w).Encode(ipc.Status{UptimeSeconds: 0})
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathRoutes:
+			_ = json.NewEncoder(w).Encode(map[string]any{"routes": []ipc.Claim{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Setenv("ROUTEUP_AGENT_SOCKET", socketPath)
+	stdout, _, err := runRoot(t, "stop", "myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopCalls.Load() < 3 || !strings.Contains(stdout, "route stopped:") {
+		t.Fatalf("stop calls = %d, output = %q", stopCalls.Load(), stdout)
+	}
+}
+
+func TestServeDetachFlagUsesConventionalPair(t *testing.T) {
+	flag := newServeCmd().Flags().Lookup("detach")
+	if flag == nil || flag.Shorthand != "d" {
+		t.Fatalf("detach flag = %#v, want -d/--detach", flag)
+	}
+	if newServeCmd().Flags().Lookup("background") != nil || newServeCmd().Flags().Lookup("bg") != nil {
+		t.Fatal("serve exposes redundant background aliases")
+	}
+}
+
+func TestDetachedServeRemovesTokenFromChildEnvironment(t *testing.T) {
+	env := withoutEnv([]string{"HOME=/tmp/home", "ROUTEUP_TOKEN=secret", "ROUTEUP_SERVER=https://example.com"}, "ROUTEUP_TOKEN")
+	joined := strings.Join(env, "\n")
+	if strings.Contains(joined, "ROUTEUP_TOKEN=") {
+		t.Fatalf("sanitized environment still contains token: %q", joined)
+	}
+	if !strings.Contains(joined, "HOME=/tmp/home") || !strings.Contains(joined, "ROUTEUP_SERVER=https://example.com") {
+		t.Fatalf("sanitized environment dropped unrelated values: %q", joined)
+	}
+}
+
+func writeConfig(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "routeup.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -98,6 +98,42 @@ func TestStopRouteWaitsForOwnerToReconcileAfterAgentRestart(t *testing.T) {
 	}
 }
 
+func TestStopRouteWaitsForOwnerControlAfterAgentRestart(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	t.Setenv(state.StateDirEnv, t.TempDir())
+	lease, err := state.RegisterOwner("myapp", state.OwnerServe, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+
+	var stopCalls atomic.Int32
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == ipc.PathOwners+"/myapp/stop":
+			if stopCalls.Add(1) < 3 {
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(ipc.ErrorBody{Error: "route owner cannot be stopped remotely; stop the holding process from its terminal"})
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathRoutes:
+			_ = json.NewEncoder(w).Encode(map[string]any{"routes": []ipc.Claim{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Setenv("ROUTEUP_AGENT_SOCKET", socketPath)
+	stdout, _, err := runRoot(t, "stop", "myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopCalls.Load() < 3 || !strings.Contains(stdout, "route stopped:") {
+		t.Fatalf("stop calls = %d, output = %q", stopCalls.Load(), stdout)
+	}
+}
+
 func TestServeDetachFlagUsesConventionalPair(t *testing.T) {
 	flag := newServeCmd().Flags().Lookup("detach")
 	if flag == nil || flag.Shorthand != "d" {

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -69,7 +69,9 @@ func runUninstall(cmd *cobra.Command, yes bool) error {
 		}
 	}
 
-	stopAgent(cmd, out)
+	if err := stopOwnersAndAgent(cmd, out); err != nil {
+		return err
+	}
 	if isolatedDir != "" {
 		certPath := filepath.Join(isolatedDir, state.CACertName)
 		if _, err := os.Stat(certPath); err == nil {
@@ -115,6 +117,99 @@ func runUninstall(cmd *cobra.Command, yes bool) error {
 	_, _ = fmt.Fprintln(out, "")
 	_, _ = fmt.Fprintln(out, styles.success("done. you can now remove the routeup binary (e.g. `brew uninstall routeup`)."))
 	return nil
+}
+
+func stopOwnersAndAgent(cmd *cobra.Command, out io.Writer) error {
+	for attempt := 0; attempt < 3; attempt++ {
+		if err := stopActiveOwners(cmd, out); err != nil {
+			return err
+		}
+		if err := stopAgent(cmd, out); err != nil {
+			return err
+		}
+		timer := time.NewTimer(250 * time.Millisecond)
+		select {
+		case <-cmd.Context().Done():
+			timer.Stop()
+			return cmd.Context().Err()
+		case <-timer.C:
+		}
+		owners, err := state.LiveOwners()
+		if err != nil {
+			return fmt.Errorf("recheck active routeup owners: %w", err)
+		}
+		if len(owners) == 0 {
+			return nil
+		}
+	}
+	return errors.New("routeup owners kept starting during uninstall; stop them and retry")
+}
+
+func stopActiveOwners(cmd *cobra.Command, out io.Writer) error {
+	owners, err := state.LiveOwners()
+	if err != nil {
+		return fmt.Errorf("read active routeup owners: %w", err)
+	}
+	if len(owners) == 0 {
+		return nil
+	}
+	for _, owner := range owners {
+		if owner.Kind != state.OwnerServe {
+			return fmt.Errorf("cannot uninstall while %s owner for route %q is active (pid %d); stop its command first", owner.Kind, owner.Route, owner.PID)
+		}
+	}
+	sockPath, err := state.AgentSocketPath()
+	if err != nil {
+		return err
+	}
+	parent := cmd.Context()
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 85*time.Second)
+	defer cancel()
+	client := agentctl.NewClient(sockPath, "", cmd.Root().Version)
+	stopped := 0
+	stoppedRoutes := make(map[string]struct{})
+	for _, owner := range owners {
+		if _, ok := stoppedRoutes[owner.Route]; ok {
+			continue
+		}
+		found, stopErr := stopRouteAfterReconcile(ctx, client, owner.Route, 75*time.Second)
+		if stopErr != nil {
+			return fmt.Errorf("stop route %q before uninstall: %w", owner.Route, stopErr)
+		}
+		if !found {
+			return fmt.Errorf("cannot uninstall while serve owner for route %q is active (pid %d)", owner.Route, owner.PID)
+		}
+		if err := waitForRouteStop(ctx, client, owner.Route); err != nil {
+			return fmt.Errorf("stop route %q before uninstall: %w", owner.Route, err)
+		}
+		stoppedRoutes[owner.Route] = struct{}{}
+		stopped++
+	}
+	if stopped > 0 {
+		_, _ = fmt.Fprintf(out, "%s %d\n", newTerminalStyles(out).success("route owners: stopped"), stopped)
+	}
+	return waitForOwnerRecordsGone(ctx)
+}
+
+func waitForOwnerRecordsGone(ctx context.Context) error {
+	for {
+		remaining, err := state.LiveOwners()
+		if err != nil {
+			return fmt.Errorf("verify routeup owners stopped: %w", err)
+		}
+		if len(remaining) == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			owner := remaining[0]
+			return fmt.Errorf("cannot uninstall while %s owner for route %q is active (pid %d): %w", owner.Kind, owner.Route, owner.PID, ctx.Err())
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }
 
 func safeIsolatedStateDir() (string, error) {
@@ -165,6 +260,7 @@ func removeIsolatedState(dir string) (bool, error) {
 		state.AgentSocketName,
 		state.AgentLogName,
 		state.AgentPIDName,
+		state.OwnersDirName,
 		state.CACertName,
 		state.CAKeyName,
 		state.ClientConfigName,
@@ -188,11 +284,11 @@ func removeIsolatedState(dir string) (bool, error) {
 }
 
 // stopAgent shuts the agent down if it's running. Best-effort.
-func stopAgent(cmd *cobra.Command, out io.Writer) {
+func stopAgent(cmd *cobra.Command, out io.Writer) error {
 	styles := newTerminalStyles(out)
 	sockPath, err := state.AgentSocketPath()
 	if err != nil {
-		return
+		return err
 	}
 	parent := cmd.Context()
 	if parent == nil {
@@ -205,12 +301,13 @@ func stopAgent(cmd *cobra.Command, out io.Writer) {
 	stopped, err := client.Stop(ctx)
 	switch {
 	case err != nil:
-		_, _ = fmt.Fprintln(out, styles.warning(fmt.Sprintf("agent: couldn't stop (%v)", err)))
+		return fmt.Errorf("stop agent before uninstall: %w", err)
 	case stopped:
 		_, _ = fmt.Fprintln(out, styles.success("agent: stopped"))
 	default:
 		_, _ = fmt.Fprintln(out, styles.muted("agent: not running"))
 	}
+	return nil
 }
 
 // confirm prompts on out and reads a yes/no answer from the command's input.

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -2,11 +2,16 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/mukul-mehta/routeup/internal/ipc"
 	"github.com/mukul-mehta/routeup/internal/state"
 )
 
@@ -25,6 +30,82 @@ func TestUninstall_CancelsOnNo(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "cancelled") {
 		t.Errorf("expected 'cancelled', got:\n%s", out.String())
+	}
+}
+
+func TestUninstallAbortsWhenAgentDoesNotStop(t *testing.T) {
+	t.Setenv(state.StateDirEnv, t.TempDir())
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case ipc.PathStatus:
+			_ = json.NewEncoder(w).Encode(ipc.Status{BootID: "still-running"})
+		case ipc.PathShutdown:
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ignored"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Setenv(state.AgentSocketEnv, socketPath)
+	cmd := newRootCmd()
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	cmd.SetContext(ctx)
+	err := stopOwnersAndAgent(cmd, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "stop agent before uninstall") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestUninstallRejectsActiveUncontrolledOwner(t *testing.T) {
+	t.Setenv(state.StateDirEnv, t.TempDir())
+	lease, err := state.RegisterOwner("runner", state.OwnerRunner, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathStatus:
+			_ = json.NewEncoder(w).Encode(ipc.Status{UptimeSeconds: 10})
+		case r.Method == http.MethodGet && r.URL.Path == ipc.PathRoutes:
+			_ = json.NewEncoder(w).Encode(map[string]any{"routes": []ipc.Claim{{Name: "runner", OwnerPID: 42}}})
+		case r.Method == http.MethodPost && r.URL.Path == ipc.PathOwners+"/runner/stop":
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(ipc.ErrorBody{Error: "route owner cannot be stopped remotely"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Setenv(state.AgentSocketEnv, socketPath)
+	cmd := newRootCmd()
+	err = stopActiveOwners(cmd, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "runner owner for route \"runner\" is active") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestUninstallRejectsStandaloneExposure(t *testing.T) {
+	t.Setenv(state.StateDirEnv, t.TempDir())
+	lease, err := state.RegisterOwner("public", state.OwnerExpose, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	socketPath := startUnixHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case ipc.PathRoutes:
+			_ = json.NewEncoder(w).Encode(map[string]any{"routes": []ipc.Claim{}})
+		case ipc.PathStatus:
+			_ = json.NewEncoder(w).Encode(ipc.Status{UptimeSeconds: 10, Exposures: []ipc.ExposureStatus{{Route: "public", OwnerPID: 42}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Setenv(state.AgentSocketEnv, socketPath)
+	cmd := newRootCmd()
+	err = stopActiveOwners(cmd, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "expose owner for route \"public\" is active") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -34,13 +34,8 @@ type Resolved struct {
 //	Targets: File port/targets, overridden per path by ROUTEUP_PORT, --port,
 //	         and --target. Errors if all are unset. Out-of-range values error.
 //
-//	Name: PositionalName (with bare-name rule) > ROUTEUP_NAME env > File.Name.
-//	      Errors if both are empty.
-//
-// Bare-name rule: if PositionalName has no dot AND File.Name is non-empty,
-// the final name is PositionalName + "." + File.Name (closest project becomes
-// the suffix). Otherwise the chosen string is used literally and parsed via
-// route.Parse.
+//	Name: PositionalName (literal) > ROUTEUP_NAME env > File.Name.
+//	      Errors if all are empty.
 func Resolve(in Inputs) (Resolved, error) {
 	targets, err := resolveTargets(in)
 	if err != nil {
@@ -55,8 +50,8 @@ func Resolve(in Inputs) (Resolved, error) {
 	return Resolved{Route: parsed, Port: route.PrimaryPort(targets), Targets: targets}, nil
 }
 
-// ResolveName applies positional/env/file precedence and the positional
-// bare-name rule, then parses the result as a route name.
+// ResolveName applies positional/env/file precedence, then parses the result as
+// a literal route name.
 func ResolveName(in Inputs) (route.Name, error) {
 	nameStr, err := resolveName(in)
 	if err != nil {
@@ -146,11 +141,11 @@ func setTarget(targets []route.Target, target route.Target) ([]route.Target, err
 	return append(targets, normalized), nil
 }
 
-// resolveName picks a name string via positional (with bare-name rule) >
-// ROUTEUP_NAME env (literal) > File.Name (literal).
+// resolveName picks a literal name string via positional > ROUTEUP_NAME env >
+// File.Name > working-directory basename.
 func resolveName(in Inputs) (string, error) {
 	if in.PositionalName != "" {
-		return applyBareName(in.PositionalName, in.File.Name), nil
+		return in.PositionalName, nil
 	}
 	if envName := strings.TrimSpace(envGet(in.Env, "ROUTEUP_NAME")); envName != "" {
 		return envName, nil
@@ -162,20 +157,6 @@ func resolveName(in Inputs) (string, error) {
 		return in.DirName, nil
 	}
 	return "", errors.New("no route name (pass a positional, set ROUTEUP_NAME, set name in config, or run from a named directory)")
-}
-
-// applyBareName implements the PLAN.md rule: if positional has no dot and a
-// project name is in scope, the project becomes the suffix; otherwise the
-// positional is used literally. No validation here — route.Parse is the
-// authority and produces specific errors downstream.
-func applyBareName(positional, project string) string {
-	if strings.Contains(positional, ".") {
-		return positional
-	}
-	if project == "" {
-		return positional
-	}
-	return positional + "." + project
 }
 
 // envGet is a nil-safe wrapper around the injected env func.

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -11,7 +11,7 @@ func envFor(vars map[string]string) func(string) string {
 	return func(k string) string { return vars[k] }
 }
 
-// TestResolve exercises the full precedence chain and bare-name resolution.
+// TestResolve exercises the full precedence chain and literal name resolution.
 // errSubstr == "" means the case must succeed; wantRoute / wantPort are checked.
 func TestResolve(t *testing.T) {
 	cases := []struct {
@@ -74,7 +74,7 @@ func TestResolve(t *testing.T) {
 			errSubstr: "out of range",
 		},
 
-		// name precedence and bare-name rule
+		// name precedence and literal positional names
 		{
 			name: "positional with dot is literal",
 			in: Inputs{
@@ -86,13 +86,13 @@ func TestResolve(t *testing.T) {
 			wantPort:  8080,
 		},
 		{
-			name: "bare positional + file name -> prefixed",
+			name: "bare positional ignores file name",
 			in: Inputs{
 				PositionalName: "api",
 				PortFlag:       8080,
 				File:           Config{Name: "myapp"},
 			},
-			wantRoute: "api.myapp",
+			wantRoute: "api",
 			wantPort:  8080,
 		},
 		{
@@ -155,7 +155,7 @@ func TestResolve(t *testing.T) {
 				Env:            envFor(map[string]string{"ROUTEUP_NAME": "envname"}),
 				File:           Config{Name: "filename"},
 			},
-			wantRoute: "cli.filename",
+			wantRoute: "cli",
 			wantPort:  8080,
 		},
 

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -28,6 +28,7 @@ const (
 const (
 	PathStatus   = "/v1/status"
 	PathRoutes   = "/v1/routes"
+	PathOwners   = "/v1/owners"
 	PathLogs     = "/v1/logs"
 	PathRequests = "/v1/requests"
 	PathShutdown = "/v1/shutdown"

--- a/internal/state/constants.go
+++ b/internal/state/constants.go
@@ -7,6 +7,7 @@ const (
 	AgentSocketName  = "agent.sock"
 	AgentLogName     = "agent.log"
 	AgentPIDName     = "agent.pid"
+	OwnersDirName    = "owners"
 	CACertName       = "ca.crt"
 	CAKeyName        = "ca.key"
 	ClientConfigName = "client.json"

--- a/internal/state/owners.go
+++ b/internal/state/owners.go
@@ -1,0 +1,147 @@
+package state
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+)
+
+// OwnerKind identifies the long-running CLI command holding desired state.
+type OwnerKind string
+
+const (
+	OwnerServe  OwnerKind = "serve"
+	OwnerRunner OwnerKind = "runner"
+	OwnerExpose OwnerKind = "expose"
+)
+
+// OwnerRecord is non-secret runtime identity for one live CLI owner. It does
+// not persist targets, exposure configuration, or credentials.
+type OwnerRecord struct {
+	ID    string    `json:"id"`
+	Route string    `json:"route"`
+	Kind  OwnerKind `json:"kind"`
+	PID   int       `json:"pid"`
+}
+
+// OwnerLease holds the runtime record for one live CLI owner.
+type OwnerLease struct {
+	path string
+}
+
+// RegisterOwner records a live CLI owner until its lease is released.
+func RegisterOwner(route string, kind OwnerKind, pid int) (*OwnerLease, error) {
+	if route == "" || pid <= 0 || !kind.valid() {
+		return nil, errors.New("route, owner kind, and pid are required")
+	}
+	dir, err := ownersDir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create owner state directory: %w", err)
+	}
+	record := OwnerRecord{ID: rand.Text(), Route: route, Kind: kind, PID: pid}
+	path := filepath.Join(dir, record.ID+".json")
+	file, err := os.CreateTemp(dir, ".owner-*.tmp")
+	if err != nil {
+		return nil, fmt.Errorf("create temporary owner state: %w", err)
+	}
+	tempPath := file.Name()
+	if err := json.NewEncoder(file).Encode(record); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tempPath)
+		return nil, fmt.Errorf("write owner state: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return nil, fmt.Errorf("close owner state: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		return nil, fmt.Errorf("publish owner state: %w", err)
+	}
+	return &OwnerLease{path: path}, nil
+}
+
+// Release removes this owner's runtime record. It is idempotent.
+func (l *OwnerLease) Release() error {
+	if l == nil || l.path == "" {
+		return nil
+	}
+	err := os.Remove(l.path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove owner state: %w", err)
+	}
+	return nil
+}
+
+// LiveOwners returns live CLI owner records and removes records whose process
+// has exited. PID reuse can retain a stale record, which deliberately fails
+// lifecycle operations closed rather than risking an unrelated process.
+func LiveOwners() ([]OwnerRecord, error) {
+	dir, err := ownersDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read owner state directory: %w", err)
+	}
+	owners := make([]OwnerRecord, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		file, err := os.Open(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("open owner state %s: %w", entry.Name(), err)
+		}
+		var owner OwnerRecord
+		decodeErr := json.NewDecoder(file).Decode(&owner)
+		closeErr := file.Close()
+		if decodeErr != nil || closeErr != nil || owner.ID == "" || owner.Route == "" || owner.PID <= 0 || !owner.Kind.valid() {
+			return nil, fmt.Errorf("invalid owner state %s", entry.Name())
+		}
+		if !ownerProcessAlive(owner.PID) {
+			_ = os.Remove(path)
+			continue
+		}
+		owners = append(owners, owner)
+	}
+	sort.Slice(owners, func(i, j int) bool { return owners[i].ID < owners[j].ID })
+	return owners, nil
+}
+
+func ownersDir() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, OwnersDirName), nil
+}
+
+func (k OwnerKind) valid() bool {
+	return k == OwnerServe || k == OwnerRunner || k == OwnerExpose
+}
+
+func ownerProcessAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/state/owners_test.go
+++ b/internal/state/owners_test.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOwnerLeaseTracksOnlyLiveOwners(t *testing.T) {
+	t.Setenv(StateDirEnv, t.TempDir())
+	lease, err := RegisterOwner("myapp", OwnerServe, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	owners, err := LiveOwners()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owners) != 1 || owners[0].Route != "myapp" || owners[0].Kind != OwnerServe || owners[0].PID != os.Getpid() {
+		t.Fatalf("owners = %#v", owners)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	owners, err = LiveOwners()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owners) != 0 {
+		t.Fatalf("owners after release = %#v", owners)
+	}
+}
+
+func TestLiveOwnersIgnoresUnpublishedTemporaryRecord(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(StateDirEnv, dir)
+	ownersPath := filepath.Join(dir, OwnersDirName)
+	if err := os.MkdirAll(ownersPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ownersPath, ".owner-crashed.tmp"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	owners, err := LiveOwners()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owners) != 0 {
+		t.Fatalf("owners = %#v", owners)
+	}
+}
+
+func TestRegisterOwnerRejectsInvalidIdentity(t *testing.T) {
+	t.Setenv(StateDirEnv, t.TempDir())
+	if _, err := RegisterOwner("", OwnerServe, os.Getpid()); err == nil {
+		t.Fatal("missing route was accepted")
+	}
+	if _, err := RegisterOwner("myapp", "unknown", os.Getpid()); err == nil {
+		t.Fatal("unknown owner kind was accepted")
+	}
+}

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ install-devel:
 
 # Stop and remove routeup-devel plus its isolated profile
 uninstall-devel:
-    @if [[ -x "{{devel_bin}}" ]]; then "{{devel_bin}}" uninstall --yes; rm -f "{{devel_bin}}"; else printf '%s\n' "development binary not found: {{devel_bin}}"; fi
+    @if [[ -x "{{devel_bin}}" ]]; then "{{devel_bin}}" uninstall --yes && rm -f "{{devel_bin}}"; else printf '%s\n' "development binary not found: {{devel_bin}}"; fi
 
 # Fast contributor checks; excludes network-heavy and OS integration tests
 check: test-race lint test-examples

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+min_version: 2.1.10
+assert_lefthook_installed: true
+
+pre-commit:
+  jobs:
+    - name: format Go source
+      glob: "*.go"
+      run: golangci-lint fmt --diff
+
+    - name: lint Go source
+      glob: "*.go"
+      run: just lint
+
+pre-push:
+  jobs:
+    - name: contributor checks
+      run: just check

--- a/scripts/integration-linux.sh
+++ b/scripts/integration-linux.sh
@@ -27,6 +27,7 @@ SERVE_LOG="$WORK/serve.log"
 RUNNER_LOG="$WORK/runner.log"
 RUNNER_RESPONSE="$WORK/runner-response.txt"
 RUNNER_NOT_FOUND="$WORK/runner-not-found.txt"
+DETACHED_RESPONSE="$WORK/detached-response.txt"
 
 HTTP_PID=""
 SERVE_PID=""
@@ -69,6 +70,7 @@ cleanup() {
 
 	stop_and_wait "$RUNNER_PID"
 	stop_and_wait "$SERVE_PID"
+	"$BIN" stop detachedci >/dev/null 2>&1 || true
 	stop_and_wait "$HTTP_PID"
 
 	if [ -n "$APP_PID" ]; then
@@ -165,6 +167,34 @@ SERVE_RESPONSE=$(<"$WORK/serve-response.txt")
 printf '%s\n' "$SERVE_RESPONSE"
 if [[ "$SERVE_RESPONSE" != *"routeup-ci-ok"* ]]; then
 	printf '%s\n' "serve response did not contain routeup-ci-ok" >&2
+	exit 1
+fi
+
+printf '%s\n' "== detached serve and cooperative stop =="
+(
+	cd "$UPSTREAM_DIR"
+	"$BIN" serve detachedci --port 8080 --detach
+)
+wait_for_https "detachedci.localhost" "/" "$DETACHED_RESPONSE"
+DETACHED_PID=$("$BIN" routes --json | python3 -c '
+import json, sys
+routes = json.load(sys.stdin)
+print(next(route["owner_pid"] for route in routes if route["name"] == "detachedci"))
+')
+"$BIN" agent restart
+wait_for_https "detachedci.localhost" "/" "$DETACHED_RESPONSE" "$DETACHED_PID"
+"$BIN" stop detachedci
+if ! wait_for_exit "$DETACHED_PID"; then
+	printf '%s\n' "detached route owner remained alive after routeup stop" >&2
+	exit 1
+fi
+if "$BIN" routes --json | python3 -c '
+import json, sys
+raise SystemExit(any(route["name"] == "detachedci" for route in json.load(sys.stdin)))
+'; then
+	:
+else
+	printf '%s\n' "detached route remained registered after routeup stop" >&2
 	exit 1
 fi
 

--- a/scripts/integration-linux.sh
+++ b/scripts/integration-linux.sh
@@ -137,10 +137,18 @@ wait_for_https() {
 
 wait_for_exit() {
 	local pid="$1"
-	local attempt
+	local attempt stat state
 	for ((attempt = 0; attempt < 50; attempt++)); do
 		if ! kill -0 "$pid" 2>/dev/null; then
 			return 0
+		fi
+		if [ -r "/proc/$pid/stat" ]; then
+			stat=$(<"/proc/$pid/stat")
+			state=${stat#*) }
+			state=${state%% *}
+			if [ "$state" = "Z" ]; then
+				return 0
+			fi
 		fi
 		sleep 0.1
 	done


### PR DESCRIPTION
- Now, the `routeup serve` command prints logs of the running route
- Add a new `--detached` flag to run `routeup serve` in the background
- Add a new `routeup stop <ROUTE_NAME` command in order to stop background routes